### PR TITLE
Added getFilename() method to PathOrUrl class

### DIFF
--- a/.github/workflows/fluentforms-ci.yml
+++ b/.github/workflows/fluentforms-ci.yml
@@ -12,10 +12,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
-    - name: Set up JDK 1.8
+    - name: Set up JDK 11
       uses: actions/setup-java@v1
       with:
-        java-version: 1.8
+        java-version: 11
     - name: Cache maven dependencies 
       uses: actions/cache@v1
       with:

--- a/.github/workflows/rest-services-ci.yml
+++ b/.github/workflows/rest-services-ci.yml
@@ -12,10 +12,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
-    - name: Set up JDK 1.8
+    - name: Set up JDK 11
       uses: actions/setup-java@v1
       with:
-        java-version: 1.8
+        java-version: 11
     - name: Cache maven dependencies 
       uses: actions/cache@v1
       with:

--- a/fluentforms/core/src/main/java/com/_4point/aem/fluentforms/api/AbsoluteOrRelativeUrl.java
+++ b/fluentforms/core/src/main/java/com/_4point/aem/fluentforms/api/AbsoluteOrRelativeUrl.java
@@ -2,9 +2,6 @@ package com._4point.aem.fluentforms.api;
 
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.nio.file.InvalidPathException;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Objects;
 
 public class AbsoluteOrRelativeUrl {
@@ -44,6 +41,7 @@ public class AbsoluteOrRelativeUrl {
 			} catch (MalformedURLException e) {
 				try {
 					URL dummyMachineUrl = new URL("http://example.com/");
+					@SuppressWarnings("unused")
 					URL dummyUrl = new URL(dummyMachineUrl, url);	// throws an exception if url is not relative.
 					return new AbsoluteOrRelativeUrl(url);	// If we get this far, it is a relative Url.
 				} catch (MalformedURLException e2) {

--- a/fluentforms/core/src/main/java/com/_4point/aem/fluentforms/api/DocumentFactory.java
+++ b/fluentforms/core/src/main/java/com/_4point/aem/fluentforms/api/DocumentFactory.java
@@ -5,8 +5,6 @@ import java.io.InputStream;
 import java.net.URL;
 import java.nio.file.Path;
 
-import org.apache.sling.api.resource.ResourceResolver;
-
 import com._4point.aem.fluentforms.impl.AdobeDocumentFactoryImpl;
 
 public interface DocumentFactory {

--- a/fluentforms/core/src/main/java/com/_4point/aem/fluentforms/api/PathOrUrl.java
+++ b/fluentforms/core/src/main/java/com/_4point/aem/fluentforms/api/PathOrUrl.java
@@ -7,6 +7,17 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Objects;
 
+/**
+ * This class is used to house a location (typically a XDP template location) that is one of the following things:
+ * 
+ *   1) A <code>Path</code> on the local file system.
+ *   2) An <code>URL</code>.
+ *   3) A <code>URL</code> that points to a location in the crx repository.
+ *   
+ *   This class will handle all three types.  You typically construct it from a String using from(String) however it can also
+ *   be constructed directly from <code>java.nio.file.Path</code> or <code>java.net.URL</code> objects.
+ *
+ */
 public class PathOrUrl {
 	private static final String CRX_URL_PROTOCOL = "crx:";
 	private static final int CRX_URL_PROTOCOL_LENGTH = CRX_URL_PROTOCOL.length();
@@ -17,6 +28,15 @@ public class PathOrUrl {
 	private final URL url;
 	private final boolean isCrxUrl;
 	
+	/**
+	 * Constructor
+	 * 
+	 * @deprecated
+	 * This constructor is slated to become private.  Use <code>PathOrUrl.from(Path path)</code> instead.
+	 * 
+	 * @param path
+	 */
+	@Deprecated
 	public PathOrUrl(Path path) {
 		super();
 		this.path = path;
@@ -24,6 +44,15 @@ public class PathOrUrl {
 		this.isCrxUrl = false;
 	}
 
+	/**
+	 * Constructor
+	 * 
+	 * @deprecated
+	 * This constructor is slated to become private.  Use <code>PathOrUrl.from(URL url)</code> instead.
+	 * 
+	 * @param url
+	 */
+	@Deprecated
 	public PathOrUrl(URL url) {
 		super();
 		this.path = null;
@@ -38,23 +67,75 @@ public class PathOrUrl {
 		this.isCrxUrl = isCrxUrl;
 	}
 
+	/**
+	 * Return the value as a <code>Path</code> object if <code>isPath()</code> is true, otherwise return null.
+	 * 
+	 * @return
+	 */
 	public Path getPath() {
 		return this.path;
 	}
 
+	/**
+	 * Return the value as an <code>URL</code> object if <code>isUrl()</code> is true, otherwise return null.
+	 * 
+	 * @return
+	 */
 	public URL getUrl() {
 		return this.isCrxUrl ? null : this.url;
 	}
 
+	/**
+	 * Return the value as a <code>String</code> object if <code>isCrxUrl()</code> is true, otherwise return null.
+	 * 
+	 * @return
+	 */
 	public String getCrxUrl() {
 		return this.isCrxUrl ? urlToCrx(this.url) : null;
 	}
 
+	/**
+	 * Does this object house a <code>Path</code> object?
+	 * 
+	 * @return true if it houses a <code>Path</code> object, otherwise false.
+	 */
 	public boolean isPath() { return this.path != null; }
+
+	/**
+	 * Does this object house a <code>URL</code> object?
+	 * 
+	 * @return true if it houses a <code>URL</code> object, otherwise false.
+	 */
 	public boolean isUrl() { return !this.isCrxUrl && this.url != null; }
+
+	/**
+	 * Does this object house a crx <code>URL</code> object?
+	 * 
+	 * @return true if it houses a crx <code>URL</code> object, otherwise false.
+	 */
 	public boolean isCrxUrl() { return this.isCrxUrl && this.url != null; }
-	
+
+	/**
+	 * Static constructor
+	 * 
+	 * @deprecated
+	 * Use <code>PathOrUrl.from(String string)</code> instead.
+	 * 
+	 * @param pathOrUrl
+	 * @return
+	 */
+	@Deprecated
 	public static PathOrUrl fromString(final String pathOrUrl) {
+		return from(pathOrUrl);
+	}
+	
+	/**
+	 * Static constructor
+	 * 
+	 * @param pathOrUrl
+	 * @return
+	 */
+	public static PathOrUrl from(final String pathOrUrl) {
 		String trimmedPathOrUrl = Objects.requireNonNull(pathOrUrl, "Null Path or Url provided.").trim();
 		if (trimmedPathOrUrl.isEmpty()) {
 			throw new IllegalArgumentException("Empty Path or Url provided.");
@@ -81,6 +162,26 @@ public class PathOrUrl {
 		}
 	}
 
+	/**
+	 * Static constructor
+	 * 
+	 * @param path
+	 * @return
+	 */
+	public static PathOrUrl from(final Path path) {
+		return new PathOrUrl(path);
+	}
+	
+	/**
+	 * Static constructor
+	 * 
+	 * @param url
+	 * @return
+	 */
+	public static PathOrUrl from(final URL url) {
+		return new PathOrUrl(url);
+	}
+	
 	@Override
 	public String toString() {
 		if (this.isPath()) {
@@ -94,11 +195,19 @@ public class PathOrUrl {
 		}
 	}
 	
-	public static URL crxToUrl(String crxUrl) throws MalformedURLException {
+	/**
+	 * Convert a crx Url into a file: URL for storage. 
+	 * 
+	 */
+	private static URL crxToUrl(String crxUrl) throws MalformedURLException {
 		return new URL( CRX_URL_SUBSTITUTE + crxUrl.substring(CRX_URL_PROTOCOL_LENGTH));
 	}
 	
-	public static String urlToCrx(URL url) {
+	/**
+	 * Convert a file: URL back into a crx Url for usage by a client. 
+	 * 
+	 */
+	private static String urlToCrx(URL url) {
 		return  CRX_URL_PROTOCOL + url.toString().substring(CRX_URL_SUBSTITUTE_LENGTH);
 	}
 }

--- a/fluentforms/core/src/main/java/com/_4point/aem/fluentforms/api/PathOrUrl.java
+++ b/fluentforms/core/src/main/java/com/_4point/aem/fluentforms/api/PathOrUrl.java
@@ -6,6 +6,7 @@ import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Objects;
+import java.util.Optional;
 
 /**
  * This class is used to house a location (typically a XDP template location) that is one of the following things:
@@ -115,6 +116,31 @@ public class PathOrUrl {
 	 */
 	public boolean isCrxUrl() { return this.isCrxUrl && this.url != null; }
 
+	public Optional<String> getFilename() {
+		if (isPath()) {
+			return Optional.ofNullable(getPath().getFileName()).map(Path::toString);
+		} else if (isUrl()) {
+			String urlPath = getUrl().getPath();
+			int lastSlashIndex = urlPath.lastIndexOf('/');
+			if (lastSlashIndex > -1 && lastSlashIndex < urlPath.length() - 1) {
+				return Optional.of(urlPath.substring(lastSlashIndex + 1));   
+			} else {
+				return Optional.empty();
+			}
+		} else if (isCrxUrl()) {
+			String urlPath = getCrxUrl();
+			int lastSlashIndex = urlPath.lastIndexOf('/');
+			if (lastSlashIndex > -1 && lastSlashIndex < urlPath.length() - 1) {
+				return Optional.of(urlPath.substring(lastSlashIndex + 1));   
+			} else {
+				return Optional.empty();
+			}
+		} else {
+			// This should never happen.
+			throw new IllegalStateException("Encountered a PathOrUrl that was not a Path, URL or CRX Url!");
+		}
+	}
+
 	/**
 	 * Static constructor
 	 * 
@@ -210,4 +236,5 @@ public class PathOrUrl {
 	private static String urlToCrx(URL url) {
 		return  CRX_URL_PROTOCOL + url.toString().substring(CRX_URL_SUBSTITUTE_LENGTH);
 	}
+
 }

--- a/fluentforms/core/src/main/java/com/_4point/aem/fluentforms/api/forms/PDFFormRenderOptions.java
+++ b/fluentforms/core/src/main/java/com/_4point/aem/fluentforms/api/forms/PDFFormRenderOptions.java
@@ -1,6 +1,5 @@
 package com._4point.aem.fluentforms.api.forms;
 
-import java.net.URL;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Locale;

--- a/fluentforms/core/src/main/java/com/_4point/aem/fluentforms/api/forms/PDFFormRenderOptionsSetter.java
+++ b/fluentforms/core/src/main/java/com/_4point/aem/fluentforms/api/forms/PDFFormRenderOptionsSetter.java
@@ -12,7 +12,6 @@ import java.util.Objects;
 import com._4point.aem.fluentforms.api.AbsoluteOrRelativeUrl;
 import com._4point.aem.fluentforms.api.Document;
 import com._4point.aem.fluentforms.api.PathOrUrl;
-import com._4point.aem.fluentforms.impl.forms.PDFFormRenderOptionsImpl;
 import com.adobe.fd.forms.api.AcrobatVersion;
 import com.adobe.fd.forms.api.CacheStrategy;
 import com.adobe.fd.forms.api.RenderAtClient;
@@ -24,11 +23,11 @@ public interface PDFFormRenderOptionsSetter {
 	PDFFormRenderOptionsSetter setCacheStrategy(CacheStrategy strategy);
 
 	default PDFFormRenderOptionsSetter setContentRoot(Path path) {
-		return setContentRoot(new PathOrUrl(path));
+		return setContentRoot(PathOrUrl.from(path));
 	}
 
 	default PDFFormRenderOptionsSetter setContentRoot(URL url) {
-		return setContentRoot(new PathOrUrl(url));
+		return setContentRoot(PathOrUrl.from(url));
 	}
 
 	PDFFormRenderOptionsSetter setContentRoot(PathOrUrl pathOrUrl);

--- a/fluentforms/core/src/main/java/com/_4point/aem/fluentforms/api/output/OutputService.java
+++ b/fluentforms/core/src/main/java/com/_4point/aem/fluentforms/api/output/OutputService.java
@@ -257,11 +257,11 @@ public interface OutputService {
 		public BatchArgumentBuilder addTemplate(PathOrUrl template);	// TODO: Add code to call addTemplate(String templateName, PathOrUrl template) 
 
 		public default BatchArgumentBuilder addTemplate(Path template) {
-			return this.addTemplate(template.getFileName().toString(), new PathOrUrl(template));
+			return this.addTemplate(template.getFileName().toString(), PathOrUrl.from(template));
 		}
 
 		public default BatchArgumentBuilder addTemplate(URL template) { 	// TODO: Add code to call addTemplate(String templateName, PathOrUrl template)
-			return this.addTemplate(new PathOrUrl(template));
+			return this.addTemplate(PathOrUrl.from(template));
 		}
 
 		public BatchArgumentBuilder addTemplate(String templateName, PathOrUrl template);
@@ -269,11 +269,11 @@ public interface OutputService {
 		public BatchArgumentBuilder addTemplates(List<PathOrUrl> templates); 	// TODO: Add code to call addTemplate(String templateName, PathOrUrl template)
 
 		public default BatchArgumentBuilder addTemplatePaths(List<Path> templates) {
-			return this.addTemplates(templates.stream().map(PathOrUrl::new).collect(Collectors.toList())); 	// TODO: Add code to call addTemplate(String templateName, PathOrUrl template)
+			return this.addTemplates(templates.stream().map(PathOrUrl::from).collect(Collectors.toList())); 	// TODO: Add code to call addTemplate(String templateName, PathOrUrl template)
 		}
 
 		public default BatchArgumentBuilder addTemplateUrls(List<URL> templates) {
-			return this.addTemplates(templates.stream().map(PathOrUrl::new).collect(Collectors.toList())); 	// TODO: Add code to call addTemplate(String templateName, PathOrUrl template)
+			return this.addTemplates(templates.stream().map(PathOrUrl::from).collect(Collectors.toList())); 	// TODO: Add code to call addTemplate(String templateName, PathOrUrl template)
 		}
 
 		public BatchArgumentBuilder addTemplateEntries(List<Map.Entry<String, PathOrUrl>> entries);
@@ -282,7 +282,7 @@ public interface OutputService {
 			// This is a good candidate for moving into a private interface method when we move to Java 11
 			return this.addTemplateEntries(
 					entries.stream().map(
-							(e)->new AbstractMap.SimpleEntry<String, PathOrUrl>(e.getKey(), new PathOrUrl(e.getValue()))
+							(e)->new AbstractMap.SimpleEntry<String, PathOrUrl>(e.getKey(), PathOrUrl.from(e.getValue()))
 						).collect(Collectors.toList())
 					);
 		}
@@ -292,7 +292,7 @@ public interface OutputService {
 			// into a single private interface method.
 			return this.addTemplateEntries(
 					entries.stream().map(
-							(e)->new AbstractMap.SimpleEntry<String, PathOrUrl>(e.getKey(), new PathOrUrl(e.getValue()))
+							(e)->new AbstractMap.SimpleEntry<String, PathOrUrl>(e.getKey(), PathOrUrl.from(e.getValue()))
 						).collect(Collectors.toList())
 					);
 		}

--- a/fluentforms/core/src/main/java/com/_4point/aem/fluentforms/api/output/PDFOutputOptionsSetter.java
+++ b/fluentforms/core/src/main/java/com/_4point/aem/fluentforms/api/output/PDFOutputOptionsSetter.java
@@ -15,11 +15,11 @@ public interface PDFOutputOptionsSetter {
 	PDFOutputOptionsSetter setContentRoot(PathOrUrl contentRoot);
 
 	default PDFOutputOptionsSetter setContentRoot(Path contentRoot) {
-		return setContentRoot(new PathOrUrl(contentRoot));
+		return setContentRoot(PathOrUrl.from(contentRoot));
 	}
 
 	default PDFOutputOptionsSetter setContentRoot(URL contentRoot) {
-		return setContentRoot(new PathOrUrl(contentRoot));
+		return setContentRoot(PathOrUrl.from(contentRoot));
 	}
 
 	PDFOutputOptionsSetter setDebugDir(Path debugDir);

--- a/fluentforms/core/src/main/java/com/_4point/aem/fluentforms/api/output/PrintedOutputOptionsSetter.java
+++ b/fluentforms/core/src/main/java/com/_4point/aem/fluentforms/api/output/PrintedOutputOptionsSetter.java
@@ -13,11 +13,11 @@ public interface PrintedOutputOptionsSetter {
 	PrintedOutputOptionsSetter setContentRoot(PathOrUrl pathOrUrl);
 
 	default PrintedOutputOptionsSetter setContentRoot(Path path) {
-		return setContentRoot(new PathOrUrl(path));
+		return setContentRoot(PathOrUrl.from(path));
 	}
 
 	default PrintedOutputOptionsSetter setContentRoot(URL url) {
-		return setContentRoot(new PathOrUrl(url));
+		return setContentRoot(PathOrUrl.from(url));
 	}
 
 	PrintedOutputOptionsSetter setCopies(int copies);

--- a/fluentforms/core/src/main/java/com/_4point/aem/fluentforms/impl/TemplateValues.java
+++ b/fluentforms/core/src/main/java/com/_4point/aem/fluentforms/impl/TemplateValues.java
@@ -34,7 +34,7 @@ public class TemplateValues {
 		if (templatesDir == null && templateParentDir != null) {
 			// No templatesDir but there's a parent dir on the template
 			// use the parent dir as the content root
-			contentRoot = new PathOrUrl(templateParentDir);
+			contentRoot = PathOrUrl.from(templateParentDir);
 		} else if (templatesDir != null && templateParentDir == null) {
 			// There's a templatesDir but no parent dir on the template
 			// so just use the templatesDir as the content root
@@ -44,13 +44,13 @@ public class TemplateValues {
 			// append the parent dir onto the templates dir to create the content root
 			// unless the parent dir is an absolute path.
 			if (templateParentDir.isAbsolute()) {
-				contentRoot = new PathOrUrl(templateParentDir);
+				contentRoot = PathOrUrl.from(templateParentDir);
 			} else if (templatesDir.isPath()) {
-				contentRoot = new PathOrUrl(templatesDir.getPath().resolve(templateParentDir));
+				contentRoot = PathOrUrl.from(templatesDir.getPath().resolve(templateParentDir));
 			} else if (templatesDir.isUrl()) {
-				contentRoot = PathOrUrl.fromString(stripTrailingSlash(templatesDir.getUrl().toString()) + URL_SEPARATOR + templateParentDir.toString());
+				contentRoot = PathOrUrl.from(stripTrailingSlash(templatesDir.getUrl().toString()) + URL_SEPARATOR + templateParentDir.toString());
 			} else if (templatesDir.isCrxUrl()) {
-				contentRoot = PathOrUrl.fromString(stripTrailingSlash(templatesDir.getCrxUrl()) + URL_SEPARATOR + templateParentDir.toString());
+				contentRoot = PathOrUrl.from(stripTrailingSlash(templatesDir.getCrxUrl()) + URL_SEPARATOR + templateParentDir.toString());
 			} else {
 				// This should never happen
 				throw new IllegalStateException("Context Root is not a Path, Url, or CrxUrl.  This should never happen.");

--- a/fluentforms/core/src/main/java/com/_4point/aem/fluentforms/impl/docassurance/DocAssuranceServiceImpl.java
+++ b/fluentforms/core/src/main/java/com/_4point/aem/fluentforms/impl/docassurance/DocAssuranceServiceImpl.java
@@ -10,8 +10,6 @@ import com._4point.aem.fluentforms.api.Transformable;
 import com._4point.aem.fluentforms.api.docassurance.DocAssuranceService;
 import com._4point.aem.fluentforms.api.docassurance.EncryptionOptions;
 import com._4point.aem.fluentforms.api.docassurance.ReaderExtensionOptions;
-import com._4point.aem.fluentforms.impl.docassurance.SafeDocAssuranceServiceAdapterWrapper;
-import com._4point.aem.fluentforms.impl.docassurance.TraditionalDocAssuranceService;
 import com.adobe.fd.docassurance.client.api.DocAssuranceServiceOperationTypes;
 import com.adobe.fd.docassurance.client.api.SignatureOptions;
 import com.adobe.fd.encryption.client.CertificateEncryptionIdentity;

--- a/fluentforms/core/src/main/java/com/_4point/aem/fluentforms/impl/forms/FormsServiceImpl.java
+++ b/fluentforms/core/src/main/java/com/_4point/aem/fluentforms/impl/forms/FormsServiceImpl.java
@@ -1,7 +1,6 @@
 package com._4point.aem.fluentforms.impl.forms;
 
 import java.io.FileNotFoundException;
-import java.io.IOException;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;

--- a/fluentforms/core/src/main/java/com/_4point/aem/fluentforms/impl/forms/PDFFormRenderOptionsImpl.java
+++ b/fluentforms/core/src/main/java/com/_4point/aem/fluentforms/impl/forms/PDFFormRenderOptionsImpl.java
@@ -1,17 +1,15 @@
 package com._4point.aem.fluentforms.impl.forms;
 
 
-import java.net.URL;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Locale;
-import java.util.Objects;
 
 import com._4point.aem.fluentforms.api.AbsoluteOrRelativeUrl;
 import com._4point.aem.fluentforms.api.Document;
 import com._4point.aem.fluentforms.api.PathOrUrl;
-import com._4point.aem.fluentforms.api.forms.PDFFormRenderOptionsSetter;
 import com._4point.aem.fluentforms.api.forms.PDFFormRenderOptions;
+import com._4point.aem.fluentforms.api.forms.PDFFormRenderOptionsSetter;
 import com.adobe.fd.forms.api.AcrobatVersion;
 import com.adobe.fd.forms.api.CacheStrategy;
 import com.adobe.fd.forms.api.RenderAtClient;

--- a/fluentforms/core/src/main/java/com/_4point/aem/fluentforms/impl/output/AdobeOutputServiceAdapter.java
+++ b/fluentforms/core/src/main/java/com/_4point/aem/fluentforms/impl/output/AdobeOutputServiceAdapter.java
@@ -3,7 +3,6 @@ package com._4point.aem.fluentforms.impl.output;
 import static com._4point.aem.fluentforms.impl.BuilderUtils.setIfNotNull;
 
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -13,15 +12,13 @@ import org.slf4j.LoggerFactory;
 
 import com._4point.aem.fluentforms.api.Document;
 import com._4point.aem.fluentforms.api.DocumentFactory;
-import com._4point.aem.fluentforms.api.forms.PDFFormRenderOptions;
 import com._4point.aem.fluentforms.api.output.BatchOptions;
 import com._4point.aem.fluentforms.api.output.BatchResult;
 import com._4point.aem.fluentforms.api.output.OutputService.OutputServiceException;
-import com._4point.aem.fluentforms.impl.AdobeDocumentFactoryImpl;
-import com._4point.aem.fluentforms.impl.forms.AdobeFormsServiceAdapter;
 import com._4point.aem.fluentforms.api.output.PDFOutputOptions;
 import com._4point.aem.fluentforms.api.output.PrintConfig;
 import com._4point.aem.fluentforms.api.output.PrintedOutputOptions;
+import com._4point.aem.fluentforms.impl.AdobeDocumentFactoryImpl;
 
 public class AdobeOutputServiceAdapter implements TraditionalOutputService {
 

--- a/fluentforms/core/src/main/java/com/_4point/aem/fluentforms/impl/output/PrintConfigImpl.java
+++ b/fluentforms/core/src/main/java/com/_4point/aem/fluentforms/impl/output/PrintConfigImpl.java
@@ -30,7 +30,7 @@ public class PrintConfigImpl implements PrintConfig {
 	}
 
 	protected PrintConfigImpl(String xdcUri, RenderType renderType) {
-		this.xdc = PathOrUrl.fromString(xdcUri);
+		this.xdc = PathOrUrl.from(xdcUri);
 		this.renderType = renderType;
 	}
 

--- a/fluentforms/core/src/test/java/com/_4point/aem/fluentforms/api/PathOrUrlTest.java
+++ b/fluentforms/core/src/test/java/com/_4point/aem/fluentforms/api/PathOrUrlTest.java
@@ -32,7 +32,7 @@ class PathOrUrlTest {
 	@ParameterizedTest
 	@ValueSource(strings = { "C:/foo/bar", "foo", "foo/bar", "C:\\foo\\bar", "\\\\foo\\bar" })
 	void testFromString_Path(String path) {
-		PathOrUrl result = PathOrUrl.fromString(path);
+		PathOrUrl result = PathOrUrl.from(path);
 		assertTrue(result.isPath(), "Expected that isPath() would be true");
 		assertFalse(result.isUrl(), "Expected that isUrl() would be false");
 		assertFalse(result.isCrxUrl(), "Expected that isCrxUrl() would be false");
@@ -44,7 +44,7 @@ class PathOrUrlTest {
 	@ParameterizedTest
 	@ValueSource(strings = { "http://example.com", "https://example.com", "file:///~/calendar" })
 	void testFromString_Url(String url) throws MalformedURLException {
-		PathOrUrl result = PathOrUrl.fromString(url);
+		PathOrUrl result = PathOrUrl.from(url);
 		assertFalse(result.isPath(), "Expected that isPath() would be false");
 		assertTrue(result.isUrl(), "Expected that isUrl() would be true");
 		assertFalse(result.isCrxUrl(), "Expected that isCrxUrl() would be false");
@@ -56,7 +56,7 @@ class PathOrUrlTest {
 	@ParameterizedTest
 	@ValueSource(strings = { "crx:/content/dam/formsanddocument", "crx://content/dam/formsanddocument", "crx://foo./?foo?#?#%foo/bar?foo" })
 	void testFromString_CrxUrl(String url) throws MalformedURLException {
-		PathOrUrl result = PathOrUrl.fromString(url);
+		PathOrUrl result = PathOrUrl.from(url);
 		assertFalse(result.isPath(), "Expected that isPath() would be false");
 		assertFalse(result.isUrl(), "Expected that isUrl() would be false");
 		assertTrue(result.isCrxUrl(), "Expected that isCrxUrl() would be true");
@@ -68,25 +68,25 @@ class PathOrUrlTest {
 	@ParameterizedTest
 	@ValueSource(strings = { "", " " })	// I'd like to find a crx: example that causes an invalid URL, but have been unable to find one.
 	void testFromString_Invalid(String str) {
-		IllegalArgumentException iaex = assertThrows(IllegalArgumentException.class, ()->PathOrUrl.fromString(str));
+		IllegalArgumentException iaex = assertThrows(IllegalArgumentException.class, ()->PathOrUrl.from(str));
 	}
 
 	@ParameterizedTest
 	@NullSource
 	void testFromString_Null(String str) {
-		NullPointerException iaex = assertThrows(NullPointerException.class, ()->PathOrUrl.fromString(str));
+		NullPointerException iaex = assertThrows(NullPointerException.class, ()->PathOrUrl.from(str));
 	}
 
 	@EnabledOnOs(OS.WINDOWS)	// Only execute on Windows, because crap://more/crap is a valid unix path.
 	@ParameterizedTest
 	@ValueSource(strings = { "crap://more/crap" })
 	void testFromString_InvalidWindows(String str) {
-		IllegalArgumentException iaex = assertThrows(IllegalArgumentException.class, ()->PathOrUrl.fromString(str));
+		IllegalArgumentException iaex = assertThrows(IllegalArgumentException.class, ()->PathOrUrl.from(str));
 	}
 
 	@Test
 	void testFromString_Null() {
-		assertThrows(NullPointerException.class, ()->PathOrUrl.fromString(null));
+		assertThrows(NullPointerException.class, ()->PathOrUrl.from((String)null));
 	}
 	
 	

--- a/fluentforms/core/src/test/java/com/_4point/aem/fluentforms/api/PathOrUrlTest.java
+++ b/fluentforms/core/src/test/java/com/_4point/aem/fluentforms/api/PathOrUrlTest.java
@@ -156,14 +156,14 @@ class PathOrUrlTest {
 	@EnumSource
 	void test_EmptyFilename(EmptyFilenameScenario scenario) throws Exception {
 		PathOrUrl underTest = PathOrUrl.from(scenario.input);
-		assertTrue(underTest.getFilename().isEmpty(), "Expected to be empty, but was '" + underTest.getFilename() + "'.");
+		assertFalse(underTest.getFilename().isPresent(), ()->"Expected to be empty, but was '" + underTest.getFilename().get() + "'.");
 		if (scenario.testType == EmptyFilenameScenario.TestType.PATH) {
 			PathOrUrl underTestOtherTest = PathOrUrl.from(Paths.get(scenario.input));
-			assertTrue(underTestOtherTest.getFilename().isEmpty(), "Expected to be empty, but was '" + underTest.getFilename() + "'.");
+			assertFalse(underTestOtherTest.getFilename().isPresent(), ()->"Expected to be empty, but was '" + underTest.getFilename().get() + "'.");
 		}
 		if (scenario.testType == EmptyFilenameScenario.TestType.URL) {
 			PathOrUrl underTestOtherTest = PathOrUrl.from(new URL(scenario.input));
-			assertTrue(underTestOtherTest.getFilename().isEmpty(), "Expected to be empty, but was '" + underTest.getFilename() + "'.");
+			assertFalse(underTestOtherTest.getFilename().isPresent(), ()->"Expected to be empty, but was '" + underTest.getFilename().get() + "'.");
 		}
 	}
 

--- a/fluentforms/core/src/test/java/com/_4point/aem/fluentforms/api/TransformableTest.java
+++ b/fluentforms/core/src/test/java/com/_4point/aem/fluentforms/api/TransformableTest.java
@@ -2,7 +2,6 @@ package com._4point.aem.fluentforms.api;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 class TransformableTest {

--- a/fluentforms/core/src/test/java/com/_4point/aem/fluentforms/api/forms/FormsServiceImplTest.java
+++ b/fluentforms/core/src/test/java/com/_4point/aem/fluentforms/api/forms/FormsServiceImplTest.java
@@ -4,14 +4,12 @@ import static com._4point.aem.fluentforms.api.TestUtils.SAMPLE_FORM;
 import static com._4point.aem.fluentforms.api.TestUtils.SAMPLE_FORMS_DIR;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.FileNotFoundException;
 import java.net.URL;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Locale;
@@ -252,7 +250,7 @@ class FormsServiceImplTest {
 	void testRenderPDFFormPathOrUrlDocumentPDFFormRenderOptions() throws Exception {
 		MockPdfRenderService svc = new MockPdfRenderService();
 
-		PathOrUrl filename = PathOrUrl.fromString("file:foo/bar.xdp");
+		PathOrUrl filename = PathOrUrl.from("file:foo/bar.xdp");
 		Document data = Mockito.mock(Document.class);
 		PDFFormRenderOptions pdfFormRenderOptions = Mockito.mock(PDFFormRenderOptions.class);
 		Document pdfResult = underTest.renderPDFForm(filename, data, pdfFormRenderOptions);
@@ -269,7 +267,7 @@ class FormsServiceImplTest {
 	void testRenderPDFFormPathOrUrlPathDocumentPDFFormRenderOptions() throws Exception {
 		MockPdfRenderService svc = new MockPdfRenderService();
 		
-		PathOrUrl filePath = PathOrUrl.fromString(SAMPLE_FORM.toString());
+		PathOrUrl filePath = PathOrUrl.from(SAMPLE_FORM.toString());
 		Document data = Mockito.mock(Document.class);
 		PDFFormRenderOptions pdfFormRenderOptions = Mockito.mock(PDFFormRenderOptions.class);
 		Document pdfResult = underTest.renderPDFForm(filePath, data, pdfFormRenderOptions);
@@ -284,7 +282,7 @@ class FormsServiceImplTest {
 	@Test
 	@DisplayName("Test RenderPDFForm(PathOrUrl,...) null arguments.")
 	void testRenderPDFFormPathOrUrl_nullArguments() throws Exception {
-		PathOrUrl filename = PathOrUrl.fromString("http://www.example.com/docs/resource1.html");
+		PathOrUrl filename = PathOrUrl.from("http://www.example.com/docs/resource1.html");
 		Document data = Mockito.mock(Document.class);
 		PDFFormRenderOptions pdfFormRenderOptions = Mockito.mock(PDFFormRenderOptions.class);
 		URL nullFilename = null;
@@ -305,7 +303,7 @@ class FormsServiceImplTest {
 	void testRenderPDFFormPathOrUrl___FormsServiceExceptionThrown() throws Exception {
 		Mockito.when(adobeFormsService.renderPDFForm(Mockito.any(String.class), Mockito.any(), Mockito.any())).thenThrow(FormsServiceException.class);
 
-		PathOrUrl filename = PathOrUrl.fromString("http://www.example.com/docs/resource1.html");
+		PathOrUrl filename = PathOrUrl.from("http://www.example.com/docs/resource1.html");
 		Document data = Mockito.mock(Document.class);
 		PDFFormRenderOptions pdfFormRenderOptions = Mockito.mock(PDFFormRenderOptions.class);
 		
@@ -472,7 +470,7 @@ class FormsServiceImplTest {
 
 		Path filePath = SAMPLE_FORM.toAbsolutePath();
 		Document data = Mockito.mock(Document.class);
-		PathOrUrl contentRootUrl = PathOrUrl.fromString("crx://foo/bar");
+		PathOrUrl contentRootUrl = PathOrUrl.from("crx://foo/bar");
 
 		// Double check that the PDFRenderOptions are working by setting all the values to not default values and then
 		// checking that they were set (by calling PDFFormRenderOptionsImplTest.assertNotEmpty(). 

--- a/fluentforms/core/src/test/java/com/_4point/aem/fluentforms/impl/TemplateValuesTest.java
+++ b/fluentforms/core/src/test/java/com/_4point/aem/fluentforms/impl/TemplateValuesTest.java
@@ -9,12 +9,10 @@ import java.net.URL;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
-import org.junit.jupiter.params.provider.ValueSource;
 
 import com._4point.aem.fluentforms.api.PathOrUrl;
 
@@ -42,7 +40,7 @@ class TemplateValuesTest {
 	@DisplayName("TemplateValues Test: Absolute Path in form with Path content root")
 	public void testTemplateValuesAbsPathwDir() throws Exception {
 		Path template = SAMPLE_FORM.toAbsolutePath();
-		PathOrUrl templatesDir = new PathOrUrl(SAMPLE_FORMS_DIR.getParent().toAbsolutePath());
+		PathOrUrl templatesDir = PathOrUrl.from(SAMPLE_FORMS_DIR.getParent().toAbsolutePath());
 		
 		TemplateValues resultTv = TemplateValues.determineTemplateValues(template, templatesDir, UsageContext.SERVER_SIDE);
 		
@@ -55,7 +53,7 @@ class TemplateValuesTest {
 	@DisplayName("TemplateValues Test: Relative Path in form with content root")
 	public void testTemplateValuesRelPathwDir() throws Exception {
 		Path template = SAMPLE_FORM.getParent().getFileName().resolve(SAMPLE_FORM.getFileName());
-		PathOrUrl templatesDir = new PathOrUrl(SAMPLE_FORMS_DIR.getParent());
+		PathOrUrl templatesDir = PathOrUrl.from(SAMPLE_FORMS_DIR.getParent());
 		
 		TemplateValues resultTv = TemplateValues.determineTemplateValues(template, templatesDir, UsageContext.SERVER_SIDE);
 		
@@ -68,7 +66,7 @@ class TemplateValuesTest {
 	public void testTemplateValuesAbsPathwUrl() throws Exception {
 		String urlString = "http://foo/bar";
 		Path template = SAMPLE_FORM.toAbsolutePath();
-		PathOrUrl templatesDir = new PathOrUrl(new URL(urlString));
+		PathOrUrl templatesDir = PathOrUrl.from(new URL(urlString));
 		
 		TemplateValues resultTv = TemplateValues.determineTemplateValues(template, templatesDir, UsageContext.SERVER_SIDE);
 		
@@ -83,7 +81,7 @@ class TemplateValuesTest {
 	public void testTemplateValuesRelPathwUrl(ScenarioVariation scenario) throws Exception {
 		Path template = SAMPLE_FORM.getParent().getFileName().resolve(SAMPLE_FORM.getFileName());
 		String urlString = "http://foo/bar";
-		PathOrUrl templatesDir = new PathOrUrl(new URL(urlString + scenario.getEndCharacter()));
+		PathOrUrl templatesDir = PathOrUrl.from(new URL(urlString + scenario.getEndCharacter()));
 		
 		TemplateValues resultTv = TemplateValues.determineTemplateValues(template, templatesDir, UsageContext.SERVER_SIDE);
 		
@@ -96,7 +94,7 @@ class TemplateValuesTest {
 	public void testTemplateValuesAbsPathwCrxUrl() throws Exception {
 		String urlString = "crx://foo/bar";
 		Path template = SAMPLE_FORM.toAbsolutePath();
-		PathOrUrl templatesDir = PathOrUrl.fromString(urlString);
+		PathOrUrl templatesDir = PathOrUrl.from(urlString);
 		
 		TemplateValues resultTv = TemplateValues.determineTemplateValues(template, templatesDir, UsageContext.SERVER_SIDE);
 		
@@ -111,7 +109,7 @@ class TemplateValuesTest {
 	public void testTemplateValuesRelPathwCrxUrl(ScenarioVariation scenario) throws Exception {
 		Path template = SAMPLE_FORM.getParent().getFileName().resolve(SAMPLE_FORM.getFileName());
 		String urlString = "crx://foo/bar";
-		PathOrUrl templatesDir = PathOrUrl.fromString(urlString + scenario.getEndCharacter());
+		PathOrUrl templatesDir = PathOrUrl.from(urlString + scenario.getEndCharacter());
 		
 		TemplateValues resultTv = TemplateValues.determineTemplateValues(template, templatesDir, UsageContext.SERVER_SIDE);
 		
@@ -147,7 +145,7 @@ class TemplateValuesTest {
 	@DisplayName("TemplateValues Test: Bad template with content root")
 	public void testBadTemplateValuesAbsPathwDir_Client() throws Exception {
 		Path template = Paths.get(BAD_TEMPLATE);
-		PathOrUrl templatesDir = new PathOrUrl(SAMPLE_FORMS_DIR.toAbsolutePath());
+		PathOrUrl templatesDir = PathOrUrl.from(SAMPLE_FORMS_DIR.toAbsolutePath());
 		
 		TemplateValues resultTv = TemplateValues.determineTemplateValues(template, templatesDir, UsageContext.CLIENT_SIDE);
 		assertEquals(templatesDir, resultTv.getContentRoot(), "Content Root wasn't what was expected.");
@@ -158,7 +156,7 @@ class TemplateValuesTest {
 	@DisplayName("TemplateValues Test: Bad template with content root")
 	public void testBadTemplateValuesAbsPathwDir_Server() {
 		Path template = Paths.get(BAD_TEMPLATE);
-		PathOrUrl templatesDir = new PathOrUrl(SAMPLE_FORMS_DIR.toAbsolutePath());
+		PathOrUrl templatesDir = PathOrUrl.from(SAMPLE_FORMS_DIR.toAbsolutePath());
 
 		FileNotFoundException e = assertThrows(FileNotFoundException.class, ()->TemplateValues.determineTemplateValues(template, templatesDir, UsageContext.SERVER_SIDE));
 		assertTrue(e.getMessage().contains("Unable to find template"), "Expected 'Unable to find template' to be in the message.");
@@ -170,7 +168,7 @@ class TemplateValuesTest {
 	@DisplayName("TemplateValues Test: Template with bad content root")
 	public void testBadTemplateValuesAbsPathwDir2() {
 		Path template = SAMPLE_FORM.getFileName();
-		PathOrUrl templatesDir = new PathOrUrl(Paths.get(BAD_CONTENT_ROOT));
+		PathOrUrl templatesDir = PathOrUrl.from(Paths.get(BAD_CONTENT_ROOT));
 
 		FileNotFoundException e = assertThrows(FileNotFoundException.class, ()->TemplateValues.determineTemplateValues(template, templatesDir, UsageContext.SERVER_SIDE));
 		assertTrue(e.getMessage().contains("Unable to find template"), "Expected 'Unable to find template' to be in the message.");
@@ -182,7 +180,7 @@ class TemplateValuesTest {
 	@DisplayName("TemplateValues Test: Non-existent relative template with content root")
 	public void testBadTemplateValuesRelPathwDir() {
 		Path template = SAMPLE_FORM.getParent().getFileName().resolve(SAMPLE_FORM.getFileName());
-		PathOrUrl templatesDir = new PathOrUrl(Paths.get(BAD_CONTENT_ROOT));
+		PathOrUrl templatesDir = PathOrUrl.from(Paths.get(BAD_CONTENT_ROOT));
 
 		FileNotFoundException e = assertThrows(FileNotFoundException.class, ()->TemplateValues.determineTemplateValues(template, templatesDir, UsageContext.SERVER_SIDE));
 		assertTrue(e.getMessage().contains("Unable to find template"), "Expected 'Unable to find template' to be in the message.");

--- a/fluentforms/core/src/test/java/com/_4point/aem/fluentforms/impl/output/AdobeOutputServiceAdapterTest.java
+++ b/fluentforms/core/src/test/java/com/_4point/aem/fluentforms/impl/output/AdobeOutputServiceAdapterTest.java
@@ -2,19 +2,11 @@ package com._4point.aem.fluentforms.impl.output;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import java.nio.file.Path;
-import java.util.Locale;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import com._4point.aem.fluentforms.api.Document;
 import com._4point.aem.fluentforms.api.PathOrUrl;
-import com._4point.aem.fluentforms.api.output.PDFOutputOptions;
-import com._4point.aem.fluentforms.api.output.PrintConfig;
-import com._4point.aem.fluentforms.api.output.PrintedOutputOptions;
 import com._4point.aem.fluentforms.impl.output.AdobeOutputServiceAdapter.PrintConfigMapping;
-import com.adobe.fd.output.api.AcrobatVersion;
 import com.adobe.fd.output.api.RenderType;
 
 class AdobeOutputServiceAdapterTest {
@@ -38,7 +30,7 @@ class AdobeOutputServiceAdapterTest {
 		assertEquals(com.adobe.fd.output.api.PrintConfig.TPCL600, PrintConfigMapping.from(PrintConfigImpl.TPCL600).get());
 		assertEquals(com.adobe.fd.output.api.PrintConfig.ZPL300, PrintConfigMapping.from(PrintConfigImpl.ZPL300).get());
 		assertEquals(com.adobe.fd.output.api.PrintConfig.ZPL600, PrintConfigMapping.from(PrintConfigImpl.ZPL600).get());
-		assertFalse(PrintConfigMapping.from(PrintConfigImpl.custom(PathOrUrl.fromString("foo"), RenderType.PCL)).isPresent());
+		assertFalse(PrintConfigMapping.from(PrintConfigImpl.custom(PathOrUrl.from("foo"), RenderType.PCL)).isPresent());
 	}
 
 	@Test
@@ -50,7 +42,7 @@ class AdobeOutputServiceAdapterTest {
 	void testToAdobePrintConfigOptions_Custom() {
 		final String testXci = "foo";
 		final RenderType testRenderType = RenderType.PCL;
-		com.adobe.fd.output.api.PrintConfig adobePrintConfig = AdobeOutputServiceAdapter.toAdobePrintConfig(PrintConfigImpl.custom(PathOrUrl.fromString(testXci), testRenderType));
+		com.adobe.fd.output.api.PrintConfig adobePrintConfig = AdobeOutputServiceAdapter.toAdobePrintConfig(PrintConfigImpl.custom(PathOrUrl.from(testXci), testRenderType));
 		assertAll(
 				()->assertEquals(testXci, adobePrintConfig.getXdcUri()),
 				()->assertEquals(testRenderType, adobePrintConfig.getRenderType())

--- a/fluentforms/core/src/test/java/com/_4point/aem/fluentforms/impl/output/OutputServiceImplTest.java
+++ b/fluentforms/core/src/test/java/com/_4point/aem/fluentforms/impl/output/OutputServiceImplTest.java
@@ -211,7 +211,7 @@ class OutputServiceImplTest {
 	void testGeneratePDFOutputPathOrUrlDocumentPDFOutputOptions() throws Exception {
 		MockPdfOutputService svc = new MockPdfOutputService();
 		
-		PathOrUrl filename = PathOrUrl.fromString("file:foo/bar.xdp");
+		PathOrUrl filename = PathOrUrl.from("file:foo/bar.xdp");
 		Document data = Mockito.mock(Document.class);
 		PDFOutputOptions options = Mockito.mock(PDFOutputOptions.class);
 		Document result = underTest.generatePDFOutput(filename, data, options);
@@ -228,7 +228,7 @@ class OutputServiceImplTest {
 	void testGeneratePDFOutputCrxUrlDocumentPDFOutputOptions() throws Exception {
 		MockPdfOutputService svc = new MockPdfOutputService();
 		
-		PathOrUrl filename = PathOrUrl.fromString("crx:/content/dam/formsanddocuments/foo/bar.xdp");
+		PathOrUrl filename = PathOrUrl.from("crx:/content/dam/formsanddocuments/foo/bar.xdp");
 		Document data = Mockito.mock(Document.class);
 		PDFOutputOptions options = Mockito.mock(PDFOutputOptions.class);
 		Document result = underTest.generatePDFOutput(filename, data, options);
@@ -245,7 +245,7 @@ class OutputServiceImplTest {
 	void testGeneratePDFOutputPathOrUrl_nullArguments() throws Exception {
 		MockPdfOutputService svc = new MockPdfOutputService();
 		
-		PathOrUrl filename = PathOrUrl.fromString("file:foo/bar.xdp");
+		PathOrUrl filename = PathOrUrl.from("file:foo/bar.xdp");
 		Document data = Mockito.mock(Document.class);
 		PDFOutputOptions options = Mockito.mock(PDFOutputOptions.class);
 		PathOrUrl nullFilename = null;
@@ -324,7 +324,7 @@ class OutputServiceImplTest {
 	void testGeneratePDFOutputUrl() throws Exception {
 		MockPdfOutputService svc = new MockPdfOutputService();
 		
-		PathOrUrl filename = PathOrUrl.fromString("file:foo/bar.xdp");
+		PathOrUrl filename = PathOrUrl.from("file:foo/bar.xdp");
 		Document data = Mockito.mock(Document.class);
 		Document result = underTest.generatePDFOutput()
 									.setAcrobatVersion(AcrobatVersion.Acrobat_10_1)
@@ -351,7 +351,7 @@ class OutputServiceImplTest {
 	void testGeneratePDFOutputPathOrUrl() throws Exception {
 		MockPdfOutputService svc = new MockPdfOutputService();
 		
-		PathOrUrl filename = PathOrUrl.fromString("file:foo/bar.xdp");
+		PathOrUrl filename = PathOrUrl.from("file:foo/bar.xdp");
 		Document data = Mockito.mock(Document.class);
 		Document result = underTest.generatePDFOutput()
 									.setAcrobatVersion(AcrobatVersion.Acrobat_10_1)
@@ -378,7 +378,7 @@ class OutputServiceImplTest {
 	void testGeneratePDFOutputCrxUrl() throws Exception {
 		MockPdfOutputService svc = new MockPdfOutputService();
 		
-		PathOrUrl filename = PathOrUrl.fromString("crx:/content/dam/formsanddocuments/foo/bar.xdp");
+		PathOrUrl filename = PathOrUrl.from("crx:/content/dam/formsanddocuments/foo/bar.xdp");
 		Document data = Mockito.mock(Document.class);
 		Document result = underTest.generatePDFOutput()
 									.setAcrobatVersion(AcrobatVersion.Acrobat_10_1)

--- a/fluentforms/core/src/test/java/com/_4point/aem/fluentforms/impl/output/PrintedOutputOptionsImplTest.java
+++ b/fluentforms/core/src/test/java/com/_4point/aem/fluentforms/impl/output/PrintedOutputOptionsImplTest.java
@@ -5,12 +5,10 @@ import static org.junit.jupiter.api.Assertions.*;
 import java.nio.file.Paths;
 import java.util.Locale;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import com._4point.aem.fluentforms.api.output.PrintConfig;
-import com.adobe.fd.output.api.AcrobatVersion;
 import com.adobe.fd.output.api.PaginationOverride;
 
 class PrintedOutputOptionsImplTest {

--- a/fluentforms/core/src/test/java/com/_4point/aem/fluentforms/testing/forms/MockFormsServiceTest.java
+++ b/fluentforms/core/src/test/java/com/_4point/aem/fluentforms/testing/forms/MockFormsServiceTest.java
@@ -20,7 +20,7 @@ class MockFormsServiceTest {
 		MockFormsService underTest = MockFormsService.createRenderFormMock(expectedResultDoc);
 		
 		Document data = mockDocumentFactory.create(expectedResultString.getBytes());
-		PathOrUrl template = PathOrUrl.fromString("crx:/test/form");
+		PathOrUrl template = PathOrUrl.from("crx:/test/form");
 		Document result = underTest.renderPDFForm()
 								   .executeOn(template, data);
 		
@@ -38,7 +38,7 @@ class MockFormsServiceTest {
 		MockFormsService underTest = MockFormsService.createRenderFormMock(mockDocumentFactory, expectedResultDoc);
 		
 		Document data = mockDocumentFactory.create(expectedResultString.getBytes());
-		PathOrUrl template = PathOrUrl.fromString("crx:/test/form");
+		PathOrUrl template = PathOrUrl.from("crx:/test/form");
 		Document result = underTest.renderPDFForm()
 								   .executeOn(template, data);
 		

--- a/fluentforms/core/src/test/java/com/_4point/aem/fluentforms/testing/output/MockOutputServiceTest.java
+++ b/fluentforms/core/src/test/java/com/_4point/aem/fluentforms/testing/output/MockOutputServiceTest.java
@@ -18,7 +18,7 @@ class MockOutputServiceTest {
 		Document expectedResultDoc = mockDocumentFactory.create(expectedResultString.getBytes());
 		MockOutputService underTest = MockOutputService.createGeneratePdfOutputMock(expectedResultDoc);
 		
-		PathOrUrl template = PathOrUrl.fromString("crx:/test/form");
+		PathOrUrl template = PathOrUrl.from("crx:/test/form");
 		Document data = mockDocumentFactory.create(expectedResultString.getBytes());
 		
 		Document result = underTest.generatePDFOutput()
@@ -56,7 +56,7 @@ class MockOutputServiceTest {
 //		};
 //		MockOutputService underTest = MockOutputService.createGeneratePdfOutputBatchMock(expectedResults);
 //		
-//		PathOrUrl template = PathOrUrl.fromString("crx:/test/form");
+//		PathOrUrl template = PathOrUrl.from("crx:/test/form");
 //		Document data = mockDocumentFactory.create(expectedResultString.getBytes());
 //		
 //		Document result = underTest.generatePDFOutputBatch(templates, data, pdfOutputOptions, batchOptions)
@@ -75,7 +75,7 @@ class MockOutputServiceTest {
 //		Document expectedResultDoc = mockDocumentFactory.create(expectedResultString.getBytes());
 //		MockOutputService underTest = MockOutputService.createGeneratePrintedOutputMock(expectedResultDoc);
 //		
-//		PathOrUrl template = PathOrUrl.fromString("crx:/test/form");
+//		PathOrUrl template = PathOrUrl.from("crx:/test/form");
 //		Document data = mockDocumentFactory.create(expectedResultString.getBytes());
 //		
 //		Document result = underTest.generatePrintedOutput()

--- a/fluentforms/examples/src/test/java/com/_4point/aem/fluentforms/examples/OutputServiceExamples.java
+++ b/fluentforms/examples/src/test/java/com/_4point/aem/fluentforms/examples/OutputServiceExamples.java
@@ -90,7 +90,7 @@ class OutputServiceExamples {
 		Document data = ServerFactory.getDefaultDocumentFactory().create(sampleData.getBytes());
 		
 		Document result = outputService.generatePDFOutput()
-								.setContentRoot(PathOrUrl.fromString("crx:/content/dam/formsanddocuments/"))
+								.setContentRoot(PathOrUrl.from("crx:/content/dam/formsanddocuments/"))
 								.setTaggedPDF(true)
 								.executeOn(Paths.get("foo/bar.xdp"), data );
 		

--- a/fluentforms/pom.xml
+++ b/fluentforms/pom.xml
@@ -50,6 +50,11 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         
+		<!--  AEM may be running in Java 8, so compile for that until it's no longer supported. -->
+		<maven.compiler.source>8</maven.compiler.source>
+		<maven.compiler.target>8</maven.compiler.target>
+        <maven.compiler.release>8</maven.compiler.release>
+
         <mockito.version>3.2.4</mockito.version>
     </properties>
 

--- a/rest-services/client/.settings/org.eclipse.jdt.core.prefs
+++ b/rest-services/client/.settings/org.eclipse.jdt.core.prefs
@@ -4,5 +4,5 @@ org.eclipse.jdt.core.compiler.compliance=1.8
 org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
 org.eclipse.jdt.core.compiler.problem.forbiddenReference=warning
 org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=ignore
-org.eclipse.jdt.core.compiler.release=disabled
+org.eclipse.jdt.core.compiler.release=enabled
 org.eclipse.jdt.core.compiler.source=1.8

--- a/rest-services/client/pom.xml
+++ b/rest-services/client/pom.xml
@@ -176,5 +176,10 @@
 			<groupId>org.glassfish.jersey.inject</groupId>
 			<artifactId>jersey-hk2</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>jakarta.xml.bind</groupId>
+			<artifactId>jakarta.xml.bind-api</artifactId>
+			<scope>test</scope>
+		</dependency>
     </dependencies>
 </project>

--- a/rest-services/client/src/main/java/com/_4point/aem/docservices/rest_services/client/helpers/RestServicesServiceAdapter.java
+++ b/rest-services/client/src/main/java/com/_4point/aem/docservices/rest_services/client/helpers/RestServicesServiceAdapter.java
@@ -13,8 +13,6 @@ import javax.ws.rs.core.Response;
 
 import org.glassfish.jersey.media.multipart.FormDataMultiPart;
 
-import com._4point.aem.docservices.rest_services.client.helpers.RestServicesServiceAdapter.RestServicesServiceException;
-
 public abstract class RestServicesServiceAdapter {
 	protected static final MediaType APPLICATION_PDF = new MediaType("application", "pdf");
 	protected static final MediaType APPLICATION_XDP = new MediaType("application", "vnd.adobe.xdp+xml");

--- a/rest-services/client/src/test/java/com/_4point/aem/docservices/rest_services/client/docassurance/RestServicesDocAssuranceServiceAdapterTest.java
+++ b/rest-services/client/src/test/java/com/_4point/aem/docservices/rest_services/client/docassurance/RestServicesDocAssuranceServiceAdapterTest.java
@@ -36,12 +36,8 @@ import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import com._4point.aem.fluentforms.api.Document;
-import com._4point.aem.fluentforms.api.docassurance.DocAssuranceService;
-import com._4point.aem.fluentforms.api.docassurance.DocAssuranceService.DocAssuranceServiceException;
 import com._4point.aem.fluentforms.api.docassurance.EncryptionOptions;
 import com._4point.aem.fluentforms.api.docassurance.ReaderExtensionOptions;
-import com._4point.aem.fluentforms.impl.docassurance.DocAssuranceServiceImpl;
-import com._4point.aem.fluentforms.impl.docassurance.ReaderExtensionOptionsImpl;
 import com._4point.aem.fluentforms.testing.MockDocumentFactory;
 import com.adobe.fd.docassurance.client.api.SignatureOptions;
 import com.adobe.fd.signatures.pdf.inputs.UnlockOptions;

--- a/rest-services/client/src/test/java/com/_4point/aem/docservices/rest_services/client/forms/RestServicesFormsServiceAdapterTest.java
+++ b/rest-services/client/src/test/java/com/_4point/aem/docservices/rest_services/client/forms/RestServicesFormsServiceAdapterTest.java
@@ -1,8 +1,20 @@
 package com._4point.aem.docservices.rest_services.client.forms;
 
-import static org.junit.jupiter.api.Assertions.*;
 import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.Locale;
 
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.Entity;
@@ -26,11 +38,9 @@ import org.mockito.Answers;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import com._4point.aem.fluentforms.api.Document;
-import com._4point.aem.fluentforms.api.DocumentFactory;
 import com._4point.aem.fluentforms.api.forms.FormsService.FormsServiceException;
 import com._4point.aem.fluentforms.api.forms.PDFFormRenderOptions;
 import com._4point.aem.fluentforms.impl.forms.PDFFormRenderOptionsImpl;
@@ -38,18 +48,6 @@ import com._4point.aem.fluentforms.testing.MockDocumentFactory;
 import com.adobe.fd.forms.api.AcrobatVersion;
 import com.adobe.fd.forms.api.CacheStrategy;
 import com.adobe.fd.forms.api.RenderAtClient;
-
-import static org.mockito.Mockito.*;
-
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.List;
-import java.util.Locale;
 
 @ExtendWith(MockitoExtension.class)
 class RestServicesFormsServiceAdapterTest {

--- a/rest-services/client/src/test/java/com/_4point/aem/docservices/rest_services/client/output/RestServicesOutputServiceAdapterTest.java
+++ b/rest-services/client/src/test/java/com/_4point/aem/docservices/rest_services/client/output/RestServicesOutputServiceAdapterTest.java
@@ -7,7 +7,6 @@ import static org.mockito.Mockito.when;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Locale;

--- a/rest-services/it.tests/.settings/org.eclipse.jdt.core.prefs
+++ b/rest-services/it.tests/.settings/org.eclipse.jdt.core.prefs
@@ -4,5 +4,5 @@ org.eclipse.jdt.core.compiler.compliance=1.8
 org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
 org.eclipse.jdt.core.compiler.problem.forbiddenReference=warning
 org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=ignore
-org.eclipse.jdt.core.compiler.release=disabled
+org.eclipse.jdt.core.compiler.release=enabled
 org.eclipse.jdt.core.compiler.source=1.8

--- a/rest-services/it.tests/src/test/java/com/_4point/aem/docservices/rest_services/it_tests/TestUtils.java
+++ b/rest-services/it.tests/src/test/java/com/_4point/aem/docservices/rest_services/it_tests/TestUtils.java
@@ -13,7 +13,6 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.function.BiConsumer;
 
 import javax.ws.rs.core.Response;
 

--- a/rest-services/it.tests/src/test/java/com/_4point/aem/docservices/rest_services/it_tests/client/docassurance/SecureDocumentTest.java
+++ b/rest-services/it.tests/src/test/java/com/_4point/aem/docservices/rest_services/it_tests/client/docassurance/SecureDocumentTest.java
@@ -1,25 +1,19 @@
 package com._4point.aem.docservices.rest_services.it_tests.client.docassurance;
 
-import static com._4point.aem.docservices.rest_services.it_tests.TestUtils.ACTUAL_RESULTS_DIR;
 import static com._4point.aem.docservices.rest_services.it_tests.TestUtils.SAMPLE_FORM_DATA_XML;
 import static com._4point.aem.docservices.rest_services.it_tests.TestUtils.SAMPLE_FORM_PDF;
 import static com._4point.aem.docservices.rest_services.it_tests.TestUtils.TEST_MACHINE_NAME;
 import static com._4point.aem.docservices.rest_services.it_tests.TestUtils.TEST_MACHINE_PORT;
 import static com._4point.aem.docservices.rest_services.it_tests.TestUtils.TEST_USER;
 import static com._4point.aem.docservices.rest_services.it_tests.TestUtils.TEST_USER_PASSWORD;
-import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.containsStringIgnoringCase;
 import static org.hamcrest.MatcherAssert.assertThat;
 
-import java.nio.file.Files;
-
-import org.apache.commons.io.IOUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import com._4point.aem.docservices.rest_services.client.docassurance.RestServicesDocAssuranceServiceAdapter;
-import com._4point.aem.docservices.rest_services.it_tests.ByteArrayString;
 import com._4point.aem.docservices.rest_services.it_tests.TestUtils;
 import com._4point.aem.fluentforms.api.Document;
 import com._4point.aem.fluentforms.api.docassurance.DocAssuranceService;

--- a/rest-services/it.tests/src/test/java/com/_4point/aem/docservices/rest_services/it_tests/client/forms/ImportDataTest.java
+++ b/rest-services/it.tests/src/test/java/com/_4point/aem/docservices/rest_services/it_tests/client/forms/ImportDataTest.java
@@ -9,11 +9,9 @@ import java.nio.file.Files;
 
 import org.apache.commons.io.IOUtils;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import com._4point.aem.docservices.rest_services.it_tests.TestUtils;
 import com._4point.aem.docservices.rest_services.client.forms.RestServicesFormsServiceAdapter;
 import com._4point.aem.docservices.rest_services.it_tests.ByteArrayString;
 import com._4point.aem.fluentforms.api.Document;

--- a/rest-services/it.tests/src/test/java/com/_4point/aem/docservices/rest_services/it_tests/client/forms/RenderPdfFormTest.java
+++ b/rest-services/it.tests/src/test/java/com/_4point/aem/docservices/rest_services/it_tests/client/forms/RenderPdfFormTest.java
@@ -1,22 +1,21 @@
 package com._4point.aem.docservices.rest_services.it_tests.client.forms;
 
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
+import static com._4point.aem.docservices.rest_services.it_tests.TestUtils.RESOURCES_DIR;
+import static com._4point.aem.docservices.rest_services.it_tests.TestUtils.SAMPLE_FORM_DATA_XML;
+import static com._4point.aem.docservices.rest_services.it_tests.TestUtils.SAMPLE_FORM_XDP;
+import static com._4point.aem.docservices.rest_services.it_tests.TestUtils.TEST_MACHINE_NAME;
+import static com._4point.aem.docservices.rest_services.it_tests.TestUtils.TEST_MACHINE_PORT;
+import static com._4point.aem.docservices.rest_services.it_tests.TestUtils.TEST_USER;
+import static com._4point.aem.docservices.rest_services.it_tests.TestUtils.TEST_USER_PASSWORD;
 
-import java.io.FileNotFoundException;
-import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Locale;
 
-import static com._4point.aem.docservices.rest_services.it_tests.TestUtils.*;
-
-import org.apache.commons.io.IOUtils;
-import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 
 import com._4point.aem.docservices.rest_services.client.forms.RestServicesFormsServiceAdapter;
-import com._4point.aem.docservices.rest_services.it_tests.ByteArrayString;
 import com._4point.aem.docservices.rest_services.it_tests.TestUtils;
 import com._4point.aem.fluentforms.api.Document;
 import com._4point.aem.fluentforms.api.PathOrUrl;
@@ -67,7 +66,7 @@ class RenderPdfFormTest {
 	@DisplayName("Test renderPdfForm() CRX Form and Data.")
 	void testRenderPdfForm_CRXFormAndData() throws Exception {
 		Document pdfResult =  underTest.renderPDFForm()
-									.setContentRoot(PathOrUrl.fromString(CRX_CONTENT_ROOT))
+									.setContentRoot(PathOrUrl.from(CRX_CONTENT_ROOT))
 									.executeOn(SAMPLE_FORM_XDP.getFileName(), SimpleDocumentFactoryImpl.getFactory().create(SAMPLE_FORM_DATA_XML.toFile()));
 		
 		TestUtils.validatePdfResult(pdfResult.getInlineData(), "RenderPdfFormClient_CRXFormAndData.pdf", true, true, false);

--- a/rest-services/it.tests/src/test/java/com/_4point/aem/docservices/rest_services/it_tests/client/output/GeneratePdfOutputTest.java
+++ b/rest-services/it.tests/src/test/java/com/_4point/aem/docservices/rest_services/it_tests/client/output/GeneratePdfOutputTest.java
@@ -1,23 +1,20 @@
 package com._4point.aem.docservices.rest_services.it_tests.client.output;
 
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
+import static com._4point.aem.docservices.rest_services.it_tests.TestUtils.SAMPLE_FORM_DATA_XML;
+import static com._4point.aem.docservices.rest_services.it_tests.TestUtils.SAMPLE_FORM_XDP;
+import static com._4point.aem.docservices.rest_services.it_tests.TestUtils.TEST_MACHINE_NAME;
+import static com._4point.aem.docservices.rest_services.it_tests.TestUtils.TEST_MACHINE_PORT;
+import static com._4point.aem.docservices.rest_services.it_tests.TestUtils.TEST_USER;
+import static com._4point.aem.docservices.rest_services.it_tests.TestUtils.TEST_USER_PASSWORD;
 
-import java.io.IOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Locale;
 
-import org.apache.commons.io.IOUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import com._4point.aem.docservices.rest_services.client.output.RestServicesOutputServiceAdapter;
-import com._4point.aem.docservices.rest_services.it_tests.ByteArrayString;
-import com._4point.aem.docservices.rest_services.it_tests.Pdf;
-import com._4point.aem.docservices.rest_services.it_tests.Pdf.PdfException;
 import com._4point.aem.docservices.rest_services.it_tests.TestUtils;
 import com._4point.aem.fluentforms.api.Document;
 import com._4point.aem.fluentforms.api.PathOrUrl;
@@ -26,8 +23,6 @@ import com._4point.aem.fluentforms.impl.SimpleDocumentFactoryImpl;
 import com._4point.aem.fluentforms.impl.UsageContext;
 import com._4point.aem.fluentforms.impl.output.OutputServiceImpl;
 import com.adobe.fd.output.api.AcrobatVersion;
-
-import static com._4point.aem.docservices.rest_services.it_tests.TestUtils.*;
 
 class GeneratePdfOutputTest {
 
@@ -69,7 +64,7 @@ class GeneratePdfOutputTest {
 	@DisplayName("Test generatePdfOutput() CRX Form and Data.")
 	void testGeneratePdfOutput_CRXFormAndData() throws Exception {
 		Document pdfResult =  underTest.generatePDFOutput()
-									.setContentRoot(PathOrUrl.fromString(CRX_CONTENT_ROOT))
+									.setContentRoot(PathOrUrl.from(CRX_CONTENT_ROOT))
 									.executeOn(SAMPLE_FORM_XDP.getFileName(), SimpleDocumentFactoryImpl.getFactory().create(SAMPLE_FORM_DATA_XML.toFile()));
 		
 		TestUtils.validatePdfResult(pdfResult.getInlineData(), "GeneratePdfOutput_CRXFormAndData.pdf", false, false, false);		

--- a/rest-services/it.tests/src/test/java/com/_4point/aem/docservices/rest_services/it_tests/server/docassurance/SecureDocumentTest.java
+++ b/rest-services/it.tests/src/test/java/com/_4point/aem/docservices/rest_services/it_tests/server/docassurance/SecureDocumentTest.java
@@ -1,19 +1,11 @@
 package com._4point.aem.docservices.rest_services.it_tests.server.docassurance;
 
-import static com._4point.aem.docservices.rest_services.it_tests.TestUtils.SAMPLE_FORM_DATA_XML;
-import static com._4point.aem.docservices.rest_services.it_tests.TestUtils.SAMPLE_FORM_PDF;
-import static com._4point.aem.docservices.rest_services.it_tests.TestUtils.TEST_MACHINE_NAME;
-import static com._4point.aem.docservices.rest_services.it_tests.TestUtils.TEST_MACHINE_PORT_STR;
-import static com._4point.aem.docservices.rest_services.it_tests.TestUtils.TEST_USER;
-import static com._4point.aem.docservices.rest_services.it_tests.TestUtils.TEST_USER_PASSWORD;
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.CoreMatchers.containsStringIgnoringCase;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.MatcherAssert.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static com._4point.aem.docservices.rest_services.it_tests.TestUtils.*;
 
 import java.io.InputStream;
-import java.nio.file.Files;
 
 import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.client.Entity;
@@ -29,7 +21,6 @@ import org.glassfish.jersey.media.multipart.MultiPartFeature;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import com._4point.aem.docservices.rest_services.it_tests.ByteArrayString;
 import com._4point.aem.docservices.rest_services.it_tests.TestUtils;
 
 public class SecureDocumentTest {

--- a/rest-services/it.tests/src/test/java/com/_4point/aem/docservices/rest_services/it_tests/server/forms/ImportDataTest.java
+++ b/rest-services/it.tests/src/test/java/com/_4point/aem/docservices/rest_services/it_tests/server/forms/ImportDataTest.java
@@ -1,16 +1,13 @@
 package com._4point.aem.docservices.rest_services.it_tests.server.forms;
 
-import static org.junit.jupiter.api.Assertions.*;
 import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static com._4point.aem.docservices.rest_services.it_tests.TestUtils.*;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 
 import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.client.Entity;
@@ -19,13 +16,11 @@ import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
-import org.apache.commons.io.Charsets;
 import org.apache.commons.io.IOUtils;
 import org.glassfish.jersey.client.authentication.HttpAuthenticationFeature;
 import org.glassfish.jersey.media.multipart.FormDataMultiPart;
 import org.glassfish.jersey.media.multipart.MultiPartFeature;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import com._4point.aem.docservices.rest_services.it_tests.ByteArrayString;

--- a/rest-services/it.tests/src/test/java/com/_4point/aem/docservices/rest_services/it_tests/server/forms/RenderPdfFormTest.java
+++ b/rest-services/it.tests/src/test/java/com/_4point/aem/docservices/rest_services/it_tests/server/forms/RenderPdfFormTest.java
@@ -8,7 +8,6 @@ import static com._4point.aem.docservices.rest_services.it_tests.TestUtils.*;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
 
 import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.client.Entity;
@@ -24,7 +23,6 @@ import org.glassfish.jersey.media.multipart.MultiPartFeature;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import com._4point.aem.docservices.rest_services.it_tests.ByteArrayString;
 import com._4point.aem.docservices.rest_services.it_tests.TestUtils;
 
 class RenderPdfFormTest {

--- a/rest-services/it.tests/src/test/java/com/_4point/aem/docservices/rest_services/it_tests/server/output/GeneratePdfOutputTest.java
+++ b/rest-services/it.tests/src/test/java/com/_4point/aem/docservices/rest_services/it_tests/server/output/GeneratePdfOutputTest.java
@@ -3,12 +3,10 @@ package com._4point.aem.docservices.rest_services.it_tests.server.output;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.*;
+import static com._4point.aem.docservices.rest_services.it_tests.TestUtils.*;
 
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-
-import static com._4point.aem.docservices.rest_services.it_tests.TestUtils.*;
 
 import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.client.Entity;
@@ -24,7 +22,6 @@ import org.glassfish.jersey.media.multipart.MultiPartFeature;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import com._4point.aem.docservices.rest_services.it_tests.ByteArrayString;
 import com._4point.aem.docservices.rest_services.it_tests.TestUtils;
 
 class GeneratePdfOutputTest {

--- a/rest-services/pom.xml
+++ b/rest-services/pom.xml
@@ -45,6 +45,7 @@
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<jersey.version>2.29.1</jersey.version>
 		<mockito.version>3.2.4</mockito.version>
+		<jaxb.version>2.3.3</jaxb.version>
 	</properties>
 
 	<build>
@@ -721,6 +722,12 @@
 				<groupId>org.glassfish.jersey.inject</groupId>
 				<artifactId>jersey-hk2</artifactId>
 				<version>${jersey.version}</version>
+			</dependency>
+			<!-- XML Bind is required to mock jax.rs.core.Response -->
+			<dependency>
+				<groupId>jakarta.xml.bind</groupId>
+				<artifactId>jakarta.xml.bind-api</artifactId>
+				<version>${jaxb.version}</version>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>

--- a/rest-services/pom.xml
+++ b/rest-services/pom.xml
@@ -41,6 +41,11 @@
 		<vault.user>admin</vault.user>
 		<vault.password>admin</vault.password>
 
+		<!--  AEM may be running in Java 8, so compile for that until it's no longer supported. -->
+		<maven.compiler.source>8</maven.compiler.source>
+		<maven.compiler.target>8</maven.compiler.target>
+        <maven.compiler.release>8</maven.compiler.release>
+
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<jersey.version>2.29.1</jersey.version>

--- a/rest-services/server/.settings/org.eclipse.jdt.core.prefs
+++ b/rest-services/server/.settings/org.eclipse.jdt.core.prefs
@@ -4,5 +4,5 @@ org.eclipse.jdt.core.compiler.compliance=1.8
 org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
 org.eclipse.jdt.core.compiler.problem.forbiddenReference=warning
 org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=ignore
-org.eclipse.jdt.core.compiler.release=disabled
+org.eclipse.jdt.core.compiler.release=enabled
 org.eclipse.jdt.core.compiler.source=1.8

--- a/rest-services/server/src/main/java/com/_4point/aem/docservices/rest_services/server/docassurance/SecureDocument.java
+++ b/rest-services/server/src/main/java/com/_4point/aem/docservices/rest_services/server/docassurance/SecureDocument.java
@@ -15,7 +15,6 @@ import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.api.servlets.HttpConstants;
 import org.apache.sling.api.servlets.SlingAllMethodsServlet;
 import org.apache.sling.servlets.annotations.SlingServletPaths;
-import org.apache.sling.servlets.annotations.SlingServletResourceTypes;
 import org.osgi.framework.Constants;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;

--- a/rest-services/server/src/main/java/com/_4point/aem/docservices/rest_services/server/dor/DocumentOfRecord.java
+++ b/rest-services/server/src/main/java/com/_4point/aem/docservices/rest_services/server/dor/DocumentOfRecord.java
@@ -4,12 +4,10 @@ import static com._4point.aem.docservices.rest_services.server.FormParameters.*;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.io.StringReader;
 import java.io.StringWriter;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
@@ -18,23 +16,18 @@ import javax.servlet.ServletException;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.transform.Transformer;
-import javax.xml.transform.TransformerConfigurationException;
 import javax.xml.transform.TransformerException;
 import javax.xml.transform.TransformerFactory;
-import javax.xml.transform.TransformerFactoryConfigurationError;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 
-import org.apache.poi.sl.draw.geom.Formula;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.SlingHttpServletResponse;
 import org.apache.sling.api.request.RequestParameter;
 import org.apache.sling.api.resource.Resource;
-import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.api.servlets.HttpConstants;
 import org.apache.sling.api.servlets.SlingAllMethodsServlet;
 import org.apache.sling.servlets.annotations.SlingServletPaths;
-import org.apache.sling.servlets.annotations.SlingServletResourceTypes;
 import org.osgi.framework.Constants;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -204,7 +197,7 @@ public class DocumentOfRecord extends SlingAllMethodsServlet {
 			
 			if (this.hasAttachments()) {
 				dorOptionsBldr.setIncludeAttachments(true)
-							  .setFileAttachments(attachments);
+							  .setFileAttachments(this.attachments);
 			}
 			
 			 return dorOptionsBldr.build();

--- a/rest-services/server/src/main/java/com/_4point/aem/docservices/rest_services/server/dor/DocumentOfRecordService.java
+++ b/rest-services/server/src/main/java/com/_4point/aem/docservices/rest_services/server/dor/DocumentOfRecordService.java
@@ -6,7 +6,6 @@ import java.util.Objects;
 
 import org.apache.sling.api.resource.Resource;
 
-import com._4point.aem.docservices.rest_services.server.dor.DocumentOfRecordService.DocumentOfRecordOptions;
 import com.adobe.aemds.guide.addon.dor.DoRGenerationException;
 import com.adobe.aemds.guide.addon.dor.DoROptions;
 import com.adobe.aemds.guide.addon.dor.DoRResult;

--- a/rest-services/server/src/main/java/com/_4point/aem/docservices/rest_services/server/forms/ExportData.java
+++ b/rest-services/server/src/main/java/com/_4point/aem/docservices/rest_services/server/forms/ExportData.java
@@ -10,10 +10,10 @@ import org.apache.sling.api.SlingHttpServletResponse;
 import org.apache.sling.api.servlets.HttpConstants;
 import org.apache.sling.api.servlets.SlingAllMethodsServlet;
 import org.apache.sling.servlets.annotations.SlingServletPaths;
-import org.apache.sling.servlets.annotations.SlingServletResourceTypes;
 import org.osgi.framework.Constants;
 import org.osgi.service.component.annotations.Component;
 
+@SuppressWarnings("serial")
 @Component(service=Servlet.class, property={Constants.SERVICE_DESCRIPTION + "=FormsService.ExportData Service",
 											"sling.servlet.methods=" + HttpConstants.METHOD_POST})
 @SlingServletPaths("/services/FormsService_ExportData")

--- a/rest-services/server/src/main/java/com/_4point/aem/docservices/rest_services/server/forms/ImportData.java
+++ b/rest-services/server/src/main/java/com/_4point/aem/docservices/rest_services/server/forms/ImportData.java
@@ -1,14 +1,7 @@
 package com._4point.aem.docservices.rest_services.server.forms;
 
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.util.Arrays;
-import java.util.List;
 import java.util.Objects;
-import java.util.Optional;
-import java.util.StringJoiner;
-import java.util.function.Function;
 import java.util.function.Supplier;
 
 import javax.servlet.Servlet;
@@ -20,7 +13,6 @@ import org.apache.sling.api.request.RequestParameter;
 import org.apache.sling.api.servlets.HttpConstants;
 import org.apache.sling.api.servlets.SlingAllMethodsServlet;
 import org.apache.sling.servlets.annotations.SlingServletPaths;
-import org.apache.sling.servlets.annotations.SlingServletResourceTypes;
 import org.osgi.framework.Constants;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;

--- a/rest-services/server/src/main/java/com/_4point/aem/docservices/rest_services/server/forms/RenderPdfForm.java
+++ b/rest-services/server/src/main/java/com/_4point/aem/docservices/rest_services/server/forms/RenderPdfForm.java
@@ -216,7 +216,7 @@ public class RenderPdfForm extends SlingAllMethodsServlet {
 		}
 
 		private RenderPdfFormParameters setContentRoot(String contentRootStr) {
-			this.contentRoot = PathOrUrl.fromString(contentRootStr);
+			this.contentRoot = PathOrUrl.from(contentRootStr);
 			return this;
 		}
 
@@ -376,7 +376,7 @@ public class RenderPdfForm extends SlingAllMethodsServlet {
 			public static TemplateParameter readParameter(RequestParameter templateParameter) {
 				ContentType templateContentType = ContentType.valueOf(templateParameter.getContentType());
 				if (templateContentType.isCompatibleWith(ContentType.TEXT_PLAIN)) {
-					return new TemplateParameter(PathOrUrl.fromString(templateParameter.getString()));
+					return new TemplateParameter(PathOrUrl.from(templateParameter.getString()));
 				} else if (templateContentType.isCompatibleWith(ContentType.APPLICATION_XDP)) {
 					return new TemplateParameter(templateParameter.get());
 				} else {

--- a/rest-services/server/src/main/java/com/_4point/aem/docservices/rest_services/server/forms/Validate.java
+++ b/rest-services/server/src/main/java/com/_4point/aem/docservices/rest_services/server/forms/Validate.java
@@ -10,10 +10,10 @@ import org.apache.sling.api.SlingHttpServletResponse;
 import org.apache.sling.api.servlets.HttpConstants;
 import org.apache.sling.api.servlets.SlingAllMethodsServlet;
 import org.apache.sling.servlets.annotations.SlingServletPaths;
-import org.apache.sling.servlets.annotations.SlingServletResourceTypes;
 import org.osgi.framework.Constants;
 import org.osgi.service.component.annotations.Component;
 
+@SuppressWarnings("serial")
 @Component(service=Servlet.class, property={Constants.SERVICE_DESCRIPTION + "=FormsService.Validate Service",
 											"sling.servlet.methods=" + HttpConstants.METHOD_POST})
 @SlingServletPaths("/services/FormsService/Validate")

--- a/rest-services/server/src/main/java/com/_4point/aem/docservices/rest_services/server/output/GeneratePdfOutput.java
+++ b/rest-services/server/src/main/java/com/_4point/aem/docservices/rest_services/server/output/GeneratePdfOutput.java
@@ -7,7 +7,6 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Locale;
-import java.util.Optional;
 import java.util.function.Supplier;
 
 import javax.servlet.Servlet;
@@ -198,7 +197,7 @@ public class GeneratePdfOutput extends SlingAllMethodsServlet {
 		}
 
 		private GeneratePdfOutputParameters setContentRoot(String contentRootStr) {
-			this.contentRoot = PathOrUrl.fromString(contentRootStr);
+			this.contentRoot = PathOrUrl.from(contentRootStr);
 			return this;
 		}
 
@@ -370,7 +369,7 @@ public class GeneratePdfOutput extends SlingAllMethodsServlet {
 			public static TemplateParameter readParameter(RequestParameter templateParameter) {
 				ContentType templateContentType = ContentType.valueOf(templateParameter.getContentType());
 				if (templateContentType.isCompatibleWith(ContentType.TEXT_PLAIN)) {
-					return new TemplateParameter(PathOrUrl.fromString(templateParameter.getString()));
+					return new TemplateParameter(PathOrUrl.from(templateParameter.getString()));
 				} else if (templateContentType.isCompatibleWith(ContentType.APPLICATION_XDP)) {
 					return new TemplateParameter(templateParameter.get());
 				} else {

--- a/rest-services/server/src/test/java/com/_4point/aem/docservices/rest_services/server/AcceptHeadersTest.java
+++ b/rest-services/server/src/test/java/com/_4point/aem/docservices/rest_services/server/AcceptHeadersTest.java
@@ -1,11 +1,8 @@
 package com._4point.aem.docservices.rest_services.server;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.hamcrest.CoreMatchers.*;
-import static org.hamcrest.MatcherAssert.*;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.Arrays;
 import java.util.Collections;

--- a/rest-services/server/src/test/java/com/_4point/aem/docservices/rest_services/server/ByteArrayStringTest.java
+++ b/rest-services/server/src/test/java/com/_4point/aem/docservices/rest_services/server/ByteArrayStringTest.java
@@ -2,7 +2,6 @@ package com._4point.aem.docservices.rest_services.server;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 class ByteArrayStringTest {

--- a/rest-services/server/src/test/java/com/_4point/aem/docservices/rest_services/server/ContentTypeTest.java
+++ b/rest-services/server/src/test/java/com/_4point/aem/docservices/rest_services/server/ContentTypeTest.java
@@ -5,7 +5,6 @@ import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.*;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 
 public class ContentTypeTest {
 

--- a/rest-services/server/src/test/java/com/_4point/aem/docservices/rest_services/server/dor/DocumentOfRecordTest.java
+++ b/rest-services/server/src/test/java/com/_4point/aem/docservices/rest_services/server/dor/DocumentOfRecordTest.java
@@ -16,7 +16,6 @@ import javax.el.MethodNotFoundException;
 import org.apache.sling.api.SlingHttpServletResponse;
 import org.apache.sling.testing.mock.sling.servlet.MockSlingHttpServletRequest;
 import org.apache.sling.testing.mock.sling.servlet.MockSlingHttpServletResponse;
-import org.apache.sling.testing.resourceresolver.MockResourceResolver;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 

--- a/rest-services/server/src/test/java/com/_4point/aem/docservices/rest_services/server/forms/ImportDataTest.java
+++ b/rest-services/server/src/test/java/com/_4point/aem/docservices/rest_services/server/forms/ImportDataTest.java
@@ -4,7 +4,6 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.*;
 
-import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -22,23 +21,18 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import com._4point.aem.fluentforms.api.Document;
 import com._4point.aem.fluentforms.api.DocumentFactory;
-import com._4point.aem.fluentforms.impl.forms.AdobeFormsServiceAdapter;
 import com._4point.aem.fluentforms.impl.forms.TraditionalFormsService;
 import com._4point.aem.fluentforms.testing.MockDocumentFactory;
 import com._4point.aem.fluentforms.testing.forms.MockTraditionalFormsService;
 import com._4point.aem.fluentforms.testing.forms.MockTraditionalFormsService.ImportDataArgs;
 import com.adobe.fd.forms.api.FormsServiceException;
-import com.google.common.collect.ImmutableList;
 
 import io.wcm.testing.mock.aem.junit5.AemContext;
 import io.wcm.testing.mock.aem.junit5.AemContextExtension;
-import uk.org.lidalia.slf4jtest.LoggingEvent;
 import uk.org.lidalia.slf4jtest.TestLogger;
 import uk.org.lidalia.slf4jtest.TestLoggerFactory;
 


### PR DESCRIPTION
Resolves #2 .  I also used the opportunity to do some cleanup.

- I removed a bunch of unused imports
- I performed some refactoring of methods on the PathOrUrl class. Specifically, I deprecated the two public constructors and fromString() in favour of using static construction methods named from().
