### PR TITLE
20230724 feature adaptive forms submit

### DIFF
--- a/spring/fluentforms-sample-cli-app/pom.xml
+++ b/spring/fluentforms-sample-cli-app/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.1.0</version>
+		<version>3.1.2</version>
 		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com._4point.aem.fluentforms</groupId>

--- a/spring/fluentforms-sample-web-app/pom.xml
+++ b/spring/fluentforms-sample-web-app/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.1.0</version>
+		<version>3.1.2</version>
 	</parent>
 	<groupId>com._4point.aem.fluentforms</groupId>
 	<artifactId>fluentforms-sample-web-app</artifactId>

--- a/spring/fluentforms-sample-web-app/src/main/java/com/_4point/aem/fluentforms/sampleapp/resources/AfSubmissionHandler.java
+++ b/spring/fluentforms-sample-web-app/src/main/java/com/_4point/aem/fluentforms/sampleapp/resources/AfSubmissionHandler.java
@@ -1,0 +1,29 @@
+package com._4point.aem.fluentforms.sampleapp.resources;
+
+import java.util.Objects;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import com._4point.aem.fluentforms.spring.AemProxyAfSubmission;
+import com._4point.aem.fluentforms.spring.AemProxyAfSubmission.AfSubmissionHandler.SubmitResponse.Response;
+
+@Component
+public class AfSubmissionHandler implements AemProxyAfSubmission.AfSubmissionHandler {
+	private final static Logger logger = LoggerFactory.getLogger(AfSubmissionHandler.class);
+	public static final String AF_TEMPLATE_NAME = "sample00002test";
+
+	@Override
+	public boolean canHandle(String formName) {
+		return Objects.equals(AF_TEMPLATE_NAME, formName);
+	}
+
+	@Override
+	public SubmitResponse processSubmission(Submission submission) {
+		// TODO: Implement a less trivial submission handler, maybe one that generates and returns a PDF.
+		logger.atInfo().log("Received submission");
+		return Response.text("Successful Submit");
+	}
+
+}

--- a/spring/fluentforms-sample-web-app/src/test/java/com/_4point/aem/fluentforms/sampleapp/resources/AfSubmissionHandlerTest.java
+++ b/spring/fluentforms-sample-web-app/src/test/java/com/_4point/aem/fluentforms/sampleapp/resources/AfSubmissionHandlerTest.java
@@ -1,0 +1,111 @@
+package com._4point.aem.fluentforms.sampleapp.resources;
+
+import static com._4point.testing.matchers.jaxrs.ResponseMatchers.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.net.URI;
+import java.util.List;
+
+import org.glassfish.jersey.media.multipart.FormDataMultiPart;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.web.server.LocalServerPort;
+
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.http.ResponseDefinition;
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+import com.github.tomakehurst.wiremock.recording.SnapshotRecordResult;
+import com.github.tomakehurst.wiremock.stubbing.StubMapping;
+
+import jakarta.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response.Status;
+
+@WireMockTest(httpPort = FluentFormsResourcesTest.WIREMOCK_PORT)
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+class AfSubmissionHandlerTest {
+	public static final String AF_TEMPLATE_NAME = "sample00002test";
+	private static final String SUBMIT_ADAPTIVE_FORM_SERVICE_PATH = "/aem/content/forms/af/" + AF_TEMPLATE_NAME + "/jcr:content/guideContainer.af.submit.jsp";
+
+	private static final boolean WIREMOCK_RECORDING = false;
+	static final int WIREMOCK_PORT = 5502;
+	
+	private static final String APPLICATION_PDF = "application/pdf";
+	private static final MediaType APPLICATION_PDF_TYPE = MediaType.valueOf(APPLICATION_PDF);
+
+	@LocalServerPort
+	private int port;
+
+	@BeforeEach
+	void setUp(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
+		if (WIREMOCK_RECORDING) {
+			WireMock.startRecording(getBaseUriString(4502));
+		}
+	}
+
+	@AfterEach
+	void tearDown() throws Exception {
+		if (WIREMOCK_RECORDING) {
+			SnapshotRecordResult recordings = WireMock.stopRecording();
+			List<StubMapping> mappings = recordings.getStubMappings();
+			System.out.println("Found " + mappings.size() + " recordings.");
+			for (StubMapping mapping : mappings) {
+				ResponseDefinition response = mapping.getResponse();
+				var jsonBody = response.getJsonBody();
+				System.out.println(jsonBody == null ? "JsonBody is null" : jsonBody.toPrettyString());
+			}
+		}
+	}
+	
+	@Test
+	void test() {
+		var mockData = mockFormData("http://localhost:8080/redirect", "{ \"foo\" : \"bar\"}");
+		
+		Response response = ClientBuilder.newClient()
+				 .target(getBaseUri(port))
+				 .path(SUBMIT_ADAPTIVE_FORM_SERVICE_PATH)
+				 .queryParam("form", "sample_template.xdp")
+				 .request()
+				 .post(Entity.entity(mockData, mockData.getMediaType()));
+
+		assertThat(response, allOf(isStatus(Status.OK), hasMediaType(MediaType.TEXT_PLAIN_TYPE), hasEntityEqualTo("Successful Submit".getBytes())));
+	}
+	
+	private static FormDataMultiPart mockFormData(String redirect, String data) {
+		final FormDataMultiPart getPdfForm = new FormDataMultiPart();
+		getPdfForm.field("guideContainerPath", "/aem/content/forms/af/" + AF_TEMPLATE_NAME + "/jcr:content/guideContainer")
+				  .field("aemFormComponentPath", "")
+				  .field("_asyncSubmit", "false")
+				  .field("_charset_", "UTF-8")
+				  .field("runtimeLocale", "en")
+				  .field("fileAttachmentMap", "{}")
+				  .field("afSubmissionInfo", "{\"computedMetaInfo\":{},\"stateOverrides\":{},\"signers\":{}}")
+				  .field("TextField1", "TextField1 Contents")
+				  .field("TextField2", "TextField2 Contents")
+				  .field("jcr:data", data)
+				  .field(":redirect", redirect)
+				  .field(":selfUrl", "/aem/content/forms/af/" + AF_TEMPLATE_NAME)
+				  .field("_guideValueMap", "yes")
+				  .field("_guideValuesMap", "{\"textdraw1555538078737\":\"<p style=\\\"text-align: center;\\\"><b>Sample Form</b></p>\\n\",\"TextField1\":\"DFGDFG\",\"TextField2\":\"DFGDG 233\",\"submit\":null}")
+				  .field("_guideAttachments", "")
+				  .field(":cq_csrf_token", "eyJleHAiOjE1NjU2MzUzNzcsImlhdCI6MTU2NTYzNDc3N30.9KB9yPr_mvIfyiwzn5S8mMh-yUzD0-BF99cJR7vW49M");
+		return getPdfForm;
+	}
+
+	private static String getBaseUriString(int port) {
+		return getBaseUri(port).toString();
+	}
+
+	private static URI getBaseUri(int port) {
+		return URI.create("http://localhost:" + port);
+	}
+
+}

--- a/spring/fluentforms-spring-boot-autoconfigure/pom.xml
+++ b/spring/fluentforms-spring-boot-autoconfigure/pom.xml
@@ -115,6 +115,15 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-source-plugin</artifactId>
 			</plugin>
+			<plugin>
+			    <groupId>org.apache.maven.plugins</groupId>
+    			<artifactId>maven-surefire-plugin</artifactId>
+    			<configuration>
+        			<excludes>
+		            	<exclude/>
+        			</excludes>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 </project>

--- a/spring/fluentforms-spring-boot-autoconfigure/pom.xml
+++ b/spring/fluentforms-spring-boot-autoconfigure/pom.xml
@@ -18,6 +18,8 @@
 		<jasypt.spring.boot.version>3.0.5</jasypt.spring.boot.version>
 		<jasypt.maven.plugin.version>3.0.5</jasypt.maven.plugin.version>
 		<fluentforms.version>0.0.2-SNAPSHOT</fluentforms.version>
+		<fp.hamcrest.matchers.version>0.0.1-SNAPSHOT</fp.hamcrest.matchers.version>
+		<wiremock.version>2.35.0</wiremock.version>
 	</properties>
 
 	<distributionManagement>
@@ -85,7 +87,13 @@
 		<dependency>
 			<groupId>com._4point.testing</groupId>
 			<artifactId>4point-hamcrest-matchers</artifactId>
-			<version>0.0.1-SNAPSHOT</version>
+			<version>${fp.hamcrest.matchers.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>com.github.tomakehurst</groupId>
+			<artifactId>wiremock-jre8-standalone</artifactId>
+			<version>${wiremock.version}</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/spring/fluentforms-spring-boot-autoconfigure/pom.xml
+++ b/spring/fluentforms-spring-boot-autoconfigure/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.1.0</version>
+		<version>3.1.2</version>
 		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com._4point.aem.fluentforms</groupId>
@@ -80,6 +80,12 @@
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>com._4point.testing</groupId>
+			<artifactId>4point-hamcrest-matchers</artifactId>
+			<version>0.0.1-SNAPSHOT</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/spring/fluentforms-spring-boot-autoconfigure/src/main/java/com/_4point/aem/fluentforms/spring/AemProxyAfSubmission.java
+++ b/spring/fluentforms-spring-boot-autoconfigure/src/main/java/com/_4point/aem/fluentforms/spring/AemProxyAfSubmission.java
@@ -1,28 +1,63 @@
 package com._4point.aem.fluentforms.spring;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+import java.util.Map.Entry;
+
+import org.glassfish.jersey.client.ChunkedInput;
+import org.glassfish.jersey.client.ClientProperties;
+import org.glassfish.jersey.client.authentication.HttpAuthenticationFeature;
 import org.glassfish.jersey.media.multipart.FormDataMultiPart;
+import org.glassfish.jersey.media.multipart.MultiPartFeature;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.HeaderParam;
+import jakarta.ws.rs.InternalServerErrorException;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.client.Client;
+import jakarta.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.client.WebTarget;
 import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.GenericType;
 import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.MultivaluedMap;
 import jakarta.ws.rs.core.Response;
 
+/**
+ * Class that handles Adaptive Form Submissions.
+ * 
+ * This class sets up an endpoint that receives all Adaptive Forms submissions.  The processing of these
+ * submissions can be configured based on the available beans available within the Spring context.
+ * 
+ * If a bean is provided that implements the AfSubmitProcessor interface, then that bean will be called
+ * for every Adaptive Form submission.
+ * 
+ * In the absence of an AfSubmitProcessor bean, then if one or more AfSubmitHandler beans are available, these will
+ * invoked in order for each Adapitive Form submission.
+ * 
+ * If no AfSubmitHandler beans are available, then all Adaptive Form submissions will be forwarded on
+ * to the configured AEM instance.
+ * 
+ */
 @Path("/aem")
 public class AemProxyAfSubmission {
 	private final static Logger logger = LoggerFactory.getLogger(AemProxyAfSubmission.class);
+	private static final String CONTENT_FORMS_AF = "content/forms/af/";
 	
 	@Autowired
 	AfSubmitProcessor submitProcessor;
 
-	@Path("content/forms/af/{remainder : .+}")
+	@Path(CONTENT_FORMS_AF + "{remainder : .+}")
     @POST
     @Consumes(MediaType.MULTIPART_FORM_DATA)
     public Response proxySubmitPost(@PathParam("remainder") String remainder, /* @HeaderParam(CorrelationId.CORRELATION_ID_HDR) final String correlationIdHdr,*/ @Context HttpHeaders headers, final FormDataMultiPart inFormData)  {
@@ -32,6 +67,14 @@ public class AemProxyAfSubmission {
 		return submitProcessor.processRequest(inFormData, headers, remainder);
 	}
 	
+	/**
+	 * Interface that classes that want to perform low-level processing of all Adaptive Forms submissions.
+	 * 
+	 * All Adaptive Form submissions will pass through an AfSubmitProcessor singleton found within the Spring
+	 * context.  Normally, this will be one of the provided AfSubmitProcessors (like AfSubmitLocalProcessor or
+	 * AfSubmitAemProxyProcessor), but can be replaced by a user supplied implementation.
+	 * 
+	 */
 	@FunctionalInterface
 	public interface AfSubmitProcessor {
 		/**
@@ -46,5 +89,124 @@ public class AemProxyAfSubmission {
 		 * @return
 		 */
 		Response processRequest(final FormDataMultiPart inFormData, HttpHeaders headers, String remainder);
+	}
+	
+	/**
+	 * This processor forwards the Adaptive Form submissions on to AEM for processing by the AEM instance.
+	 * 
+	 * This is typically used if the AEM Forms Data model will be used for processing the submission.
+	 * 
+	 * This is the default submit processor if no other type of submit processing is configured in the
+	 * Spring context.  
+	 * 
+	 */
+	public static class AfSubmitAemProxyProcessor implements AfSubmitProcessor {
+
+		private final AemConfiguration aemConfig;
+		private final Client httpClient;
+		
+		public AfSubmitAemProxyProcessor(AemConfiguration aemConfig) {
+			this.aemConfig = aemConfig;
+	    	this.httpClient = ClientBuilder.newClient().register(HttpAuthenticationFeature.basic(aemConfig.user(), aemConfig.password())).register(MultiPartFeature.class);
+		}
+
+		@Override
+		public Response processRequest(FormDataMultiPart formSubmission, HttpHeaders headers, String remainder) {
+//			// TODO: Convert this to a fluent logger call using a lambda.
+//			String formData = formSubmission.getField("jcr:data").getEntityAs(String.class);
+//	    	logger.trace("AF Submit Proxy: Data = '{}'", formData != null ? formData : "null");
+//			
+//	    	// Transfer to AEM
+//	    	String contentType = headers.getMediaType().toString();
+//	    	String cookie = headers.getHeaderString("cookie");
+//			WebTarget webTarget = httpClient.target(aemConfig.url())
+//									.property(ClientProperties.FOLLOW_REDIRECTS, Boolean.FALSE)
+//									.path("/" + CONTENT_FORMS_AF + remainder);
+//
+//			logger.atDebug().log(()->"Proxying Submit POST request for target '" + webTarget.getUri().toString() + "'.");
+//			Response result = webTarget.request()
+//				.header("cookie", cookie)
+//				.post(Entity.entity(formSubmission , contentType));
+//
+//			logger.atDebug().log(()->"AEM Response = " + result.getStatus());
+//			logger.atDebug().log(()->"AEM Response Location = " + result.getLocation());
+//
+//			String aemResponseEncoding = result.getHeaderString("Transfer-Encoding");
+//			if (aemResponseEncoding != null && aemResponseEncoding.equalsIgnoreCase("chunked")) {
+//				logger.debug("Returning chunked response from AEM.");
+//				return Response.status(result.getStatus()).entity(new ByteArrayInputStream(transferFromAem(result, logger)))
+//							   .type(result.getMediaType())
+////							   .header(CorrelationId.CORRELATION_ID_HDR, correlationId)
+//							   .build();
+//			} else  {
+//				logger.debug("Returning response from AEM.");
+//				return Response.fromResponse(result)
+////							   .header(CorrelationId.CORRELATION_ID_HDR, correlationId)
+//							   .build();
+//			}
+			return Response.ok().entity("AfSubmitAemProxyProcessor Response").build();
+		}
+		
+		/**
+		 * Transfers a response from AEM and returns it in a byte array.  It handles chunked responses.
+		 * 
+		 * @param result	Response object from AEM
+		 * @param logger	Logger for logging any errors/warnings/etc.
+		 * @return
+		 * @throws IOException
+		 */
+		private static byte[] transferFromAem(Response result, Logger logger) {
+			try {
+				if (logger.isDebugEnabled()) {
+					logger.debug("AEM Response Mediatype=" + (result.getMediaType() != null ? result.getMediaType().toString(): "null"));
+					MultivaluedMap<String, Object> headers = result.getHeaders();
+					for(Entry<String, List<Object>> entry : headers.entrySet()) {
+						String msgLine = "For header '" + entry.getKey() + "', ";
+						for (Object value : entry.getValue()) { 
+							msgLine += "'" + value.toString() + "' ";
+						}
+						logger.debug(msgLine);
+					}
+				}
+				
+				String aemResponseEncoding = result.getHeaderString("Transfer-Encoding");
+				if (aemResponseEncoding != null && aemResponseEncoding.equalsIgnoreCase("chunked")) {
+					// They've sent back chunked response.
+					logger.debug("Found a chunked encoding.");
+					final ChunkedInput<byte[]> chunkedInput = result.readEntity(new GenericType<ChunkedInput<byte[]>>() {});
+					byte[] chunk;
+					ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+					try (buffer) {
+						while ((chunk = chunkedInput.read()) != null) {
+							buffer.writeBytes(chunk);
+							logger.debug("Read chunk from AEM response.");
+						}
+					}
+					
+					return buffer.toByteArray();
+				} else {
+					return ((InputStream)result.getEntity()).readAllBytes();
+				}
+			} catch (IllegalStateException | IOException e) {
+				throw new InternalServerErrorException("Error while processing transferring result from AEM.", e);
+			}
+		}
+	    
+
+	}
+
+	/**
+	 * This processor will process Adaptive Forms submissions locally without sending anything to AEM.
+	 * 
+	 * It will invoke one or more AfSubmitHandlers that have been configured in the Spring context.
+	 * 
+	 */
+	public static class AfSubmitLocalProcessor implements AfSubmitProcessor {
+
+		@Override
+		public Response processRequest(FormDataMultiPart inFormData, HttpHeaders headers, String remainder) {
+			return Response.ok().entity("AfSubmitLocalProcessor Response").build();
+		}
+		
 	}
 }

--- a/spring/fluentforms-spring-boot-autoconfigure/src/main/java/com/_4point/aem/fluentforms/spring/AemProxyAfSubmission.java
+++ b/spring/fluentforms-spring-boot-autoconfigure/src/main/java/com/_4point/aem/fluentforms/spring/AemProxyAfSubmission.java
@@ -1,0 +1,50 @@
+package com._4point.aem.fluentforms.spring;
+
+import org.glassfish.jersey.media.multipart.FormDataMultiPart;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.HeaderParam;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+@Path("/aem")
+public class AemProxyAfSubmission {
+	private final static Logger logger = LoggerFactory.getLogger(AemProxyAfSubmission.class);
+	
+	@Autowired
+	AfSubmitProcessor submitProcessor;
+
+	@Path("content/forms/af/{remainder : .+}")
+    @POST
+    @Consumes(MediaType.MULTIPART_FORM_DATA)
+    public Response proxySubmitPost(@PathParam("remainder") String remainder, /* @HeaderParam(CorrelationId.CORRELATION_ID_HDR) final String correlationIdHdr,*/ @Context HttpHeaders headers, final FormDataMultiPart inFormData)  {
+		logger.atInfo().addArgument(()->submitProcessor != null ?  submitProcessor.getClass().getName() : "null" ).log("Submit proxy called. SubmitProcessor={}");
+//		final String correlationId = CorrelationId.generate(correlationIdHdr);
+//		ProcessingMetadataBuilder pmBuilder = ProcessingMetadata.start(correlationId);
+		return submitProcessor.processRequest(inFormData, headers, remainder);
+	}
+	
+	@FunctionalInterface
+	public interface AfSubmitProcessor {
+		/**
+		 * Processor to process incoming Adaptive Forms submit.
+		 * 
+		 * @param inFormData
+		 * 		incoming form data
+		 * @param headers
+		 * 		incoming HTTP headers
+		 * @param remainder
+		 * 		Adaptive Forms location path (relative to /content/forms/af/)
+		 * @return
+		 */
+		Response processRequest(final FormDataMultiPart inFormData, HttpHeaders headers, String remainder);
+	}
+}

--- a/spring/fluentforms-spring-boot-autoconfigure/src/main/java/com/_4point/aem/fluentforms/spring/AemProxyAfSubmission.java
+++ b/spring/fluentforms-spring-boot-autoconfigure/src/main/java/com/_4point/aem/fluentforms/spring/AemProxyAfSubmission.java
@@ -4,12 +4,18 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
+import java.util.Map;
 import java.util.Map.Entry;
+import java.util.function.Function;
+import java.util.function.Predicate;
 
 import org.glassfish.jersey.client.ChunkedInput;
 import org.glassfish.jersey.client.ClientProperties;
 import org.glassfish.jersey.client.authentication.HttpAuthenticationFeature;
+import org.glassfish.jersey.media.multipart.BodyPartEntity;
+import org.glassfish.jersey.media.multipart.FormDataBodyPart;
 import org.glassfish.jersey.media.multipart.FormDataMultiPart;
 import org.glassfish.jersey.media.multipart.MultiPartFeature;
 import org.slf4j.Logger;
@@ -17,7 +23,6 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import jakarta.ws.rs.Consumes;
-import jakarta.ws.rs.HeaderParam;
 import jakarta.ws.rs.InternalServerErrorException;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
@@ -43,10 +48,12 @@ import jakarta.ws.rs.core.Response;
  * for every Adaptive Form submission.
  * 
  * In the absence of an AfSubmitProcessor bean, then if one or more AfSubmitHandler beans are available, these will
- * invoked in order for each Adapitive Form submission.
+ * invoked in order for each Adaptive Form submission.
  * 
  * If no AfSubmitHandler beans are available, then all Adaptive Form submissions will be forwarded on
  * to the configured AEM instance.
+ * 
+ * 
  * 
  */
 @Path("/aem")
@@ -67,6 +74,49 @@ public class AemProxyAfSubmission {
 		return submitProcessor.processRequest(inFormData, headers, remainder);
 	}
 	
+	// NOTE:  The following method is not currently in use however it will be at some future point when the
+	//        ability to customize the submission going to AEM is added.  Currently the code only allows
+	//        a developer to forward an unaltered version of the submission to AEM.  At some point in the future
+	//        a developer will be able to provide a bean that this function will use to allow the developer to 
+	//        perform operations on the submission before it is forwarded on tho AEM.
+	/**
+	 * Transforms a FormDataMultiPart object using a set of provided functions.
+	 * 
+	 * Accepts incoming form data, in the form of a FormDataMultiPart object and a Map collection of functions.  It walks through the
+	 * parts and if it finds a function in the Map with the same name it executes that function on the the data from the corresponding part.
+	 * It accumulates and returns the result in another FormDataMultiPart object.
+	 * 
+	 * @param inFormData	incoming form data
+	 * @param fieldFunctions	set of functions that correspond to specific parts
+	 * @param logger	logger for logging messages
+	 * @return
+	 * @throws IOException
+	 */
+	public static FormDataMultiPart transformFormData(final FormDataMultiPart inFormData, final Map<String, Function<byte[], byte[]>> fieldFunctions, Logger logger) {
+		try {
+			FormDataMultiPart outFormData = new FormDataMultiPart();
+			var fields = inFormData.getFields();
+			logger.atDebug().log(()->"Found " + fields.size()  + " fields");
+			
+			for (var fieldEntry : fields.entrySet()) {
+				String fieldName = fieldEntry.getKey();
+				for (FormDataBodyPart fieldData : fieldEntry.getValue()) {
+					logger.atDebug().log(()->"Copying '" + fieldName  + "' field");
+					byte[] fieldBytes = ((BodyPartEntity)fieldData.getEntity()).getInputStream().readAllBytes();
+					logger.atTrace().log(()->"Fieldname '" + fieldName + "' is '" + new String(fieldBytes) + "'.");
+					var fieldFn = fieldFunctions.getOrDefault(fieldName, Function.identity());	// Look for an entry in fieldFunctions table for this field.  Return the Identity function if we don't find one.
+					byte[] modifiedFieldBytes = fieldFn.apply(fieldBytes);
+					if (modifiedFieldBytes != null) {	// If the function returned bytes (if not, then remove that part)
+						outFormData.field(fieldName, new String(modifiedFieldBytes, StandardCharsets.UTF_8));	// Apply the field function to bytes.
+					}
+				}
+			}
+			return outFormData;
+		} catch (IOException e) {
+			throw new InternalServerErrorException("Error while transforming submission data.", e);
+		}
+	}
+
 	/**
 	 * Interface that classes that want to perform low-level processing of all Adaptive Forms submissions.
 	 * 
@@ -91,6 +141,25 @@ public class AemProxyAfSubmission {
 		Response processRequest(final FormDataMultiPart inFormData, HttpHeaders headers, String remainder);
 	}
 	
+	@FunctionalInterface
+	public interface AfFormDataTransformer {
+		/**
+		 * If one or more of these are available in the Spring context, they will be run against the incoming
+		 * data before it is processed.
+		 * 
+		 * This can be useful when used with the AfSubmitAemProxyProcessor to transform the data before it 
+		 * is sent to AEM.
+		 * 
+		 * This can be useful when used with the AfSubmitLocalProcessor to capture data from the initial
+		 * Adaptive Form submission that may not normally be passed to the AfSubmitHandler.
+		 * 
+		 * @param inFormData
+		 * 		incoming form data object
+		 * @return
+		 * 		outgoing form data object
+		 */
+		FormDataMultiPart transformFormData(final FormDataMultiPart inFormData);
+	}
 	/**
 	 * This processor forwards the Adaptive Form submissions on to AEM for processing by the AEM instance.
 	 * 
@@ -112,39 +181,39 @@ public class AemProxyAfSubmission {
 
 		@Override
 		public Response processRequest(FormDataMultiPart formSubmission, HttpHeaders headers, String remainder) {
-//			// TODO: Convert this to a fluent logger call using a lambda.
-//			String formData = formSubmission.getField("jcr:data").getEntityAs(String.class);
-//	    	logger.trace("AF Submit Proxy: Data = '{}'", formData != null ? formData : "null");
-//			
-//	    	// Transfer to AEM
-//	    	String contentType = headers.getMediaType().toString();
-//	    	String cookie = headers.getHeaderString("cookie");
-//			WebTarget webTarget = httpClient.target(aemConfig.url())
-//									.property(ClientProperties.FOLLOW_REDIRECTS, Boolean.FALSE)
-//									.path("/" + CONTENT_FORMS_AF + remainder);
-//
-//			logger.atDebug().log(()->"Proxying Submit POST request for target '" + webTarget.getUri().toString() + "'.");
-//			Response result = webTarget.request()
-//				.header("cookie", cookie)
-//				.post(Entity.entity(formSubmission , contentType));
-//
-//			logger.atDebug().log(()->"AEM Response = " + result.getStatus());
-//			logger.atDebug().log(()->"AEM Response Location = " + result.getLocation());
-//
-//			String aemResponseEncoding = result.getHeaderString("Transfer-Encoding");
-//			if (aemResponseEncoding != null && aemResponseEncoding.equalsIgnoreCase("chunked")) {
-//				logger.debug("Returning chunked response from AEM.");
-//				return Response.status(result.getStatus()).entity(new ByteArrayInputStream(transferFromAem(result, logger)))
-//							   .type(result.getMediaType())
-////							   .header(CorrelationId.CORRELATION_ID_HDR, correlationId)
-//							   .build();
-//			} else  {
-//				logger.debug("Returning response from AEM.");
-//				return Response.fromResponse(result)
-////							   .header(CorrelationId.CORRELATION_ID_HDR, correlationId)
-//							   .build();
-//			}
-			return Response.ok().entity("AfSubmitAemProxyProcessor Response").build();
+	    	logger.atTrace().addArgument(()->{	String formData = formSubmission.getField("jcr:data").getEntityAs(String.class); 
+	    										return formData != null ? formData : "null"; 
+	    									  })
+	    					.log("AF Submit Proxy: Data = '{}'");
+			
+	    	// Transfer to AEM
+	    	String contentType = headers.getMediaType().toString();
+	    	String cookie = headers.getHeaderString("cookie");
+			WebTarget webTarget = httpClient.target(aemConfig.url())
+									.property(ClientProperties.FOLLOW_REDIRECTS, Boolean.FALSE)
+									.path("/" + CONTENT_FORMS_AF + remainder);
+
+			logger.atDebug().log(()->"Proxying Submit POST request for target '" + webTarget.getUri().toString() + "'.");
+			Response result = webTarget.request()
+									   .header("cookie", cookie)
+									   .post(Entity.entity(formSubmission , contentType));
+
+			logger.atDebug().log(()->"AEM Response = " + result.getStatus());
+			logger.atDebug().log(()->"AEM Response Location = " + result.getLocation());
+
+			String aemResponseEncoding = result.getHeaderString("Transfer-Encoding");
+			if (aemResponseEncoding != null && aemResponseEncoding.equalsIgnoreCase("chunked")) {
+				logger.atDebug().log("Returning chunked response from AEM.");
+				return Response.status(result.getStatus()).entity(new ByteArrayInputStream(transferFromAem(result, logger)))
+							   .type(result.getMediaType())
+//							   .header(CorrelationId.CORRELATION_ID_HDR, correlationId)
+							   .build();
+			} else  {
+				logger.atDebug().log("Returning response from AEM.");
+				return Response.fromResponse(result)
+//							   .header(CorrelationId.CORRELATION_ID_HDR, correlationId)
+							   .build();
+			}
 		}
 		
 		/**
@@ -191,7 +260,6 @@ public class AemProxyAfSubmission {
 				throw new InternalServerErrorException("Error while processing transferring result from AEM.", e);
 			}
 		}
-	    
 
 	}
 
@@ -202,6 +270,19 @@ public class AemProxyAfSubmission {
 	 * 
 	 */
 	public static class AfSubmitLocalProcessor implements AfSubmitProcessor {
+		
+		public interface AfSubmitHandler {
+			public record SubmitResponse(byte[] responseBytes, String mediaType) {};
+			
+			Predicate<String> canHandle();
+			
+		}
+		
+		private final List<AfSubmitHandler> submitHandlers;
+
+		private AfSubmitLocalProcessor(List<AfSubmitHandler> submitHandlers) {
+			this.submitHandlers = submitHandlers;
+		}
 
 		@Override
 		public Response processRequest(FormDataMultiPart inFormData, HttpHeaders headers, String remainder) {

--- a/spring/fluentforms-spring-boot-autoconfigure/src/main/java/com/_4point/aem/fluentforms/spring/AemProxyAfSubmission.java
+++ b/spring/fluentforms-spring-boot-autoconfigure/src/main/java/com/_4point/aem/fluentforms/spring/AemProxyAfSubmission.java
@@ -280,7 +280,44 @@ public class AemProxyAfSubmission {
 			/**
 			 * A Normal response with a 200 HTTP status code (204 if the responseBytes variable is empty)
 			 */
-			public record Response(byte[] responseBytes, String mediaType) implements SubmitResponse {};
+			public record Response(byte[] responseBytes, String mediaType) implements SubmitResponse {
+				/**
+				 * Creates a text response from a String
+				 * 
+				 * @param text
+				 * 		Text to go into the response.
+				 * @return
+				 * 		Response object with a media type of "text/plain"
+				 */
+				public static Response text(String text) { return new Response(text.getBytes(StandardCharsets.UTF_8), MediaType.TEXT_PLAIN); }
+				/**
+				 * Creates an HTML response from a String
+				 * 
+				 * @param html
+				 * 		String containing HTML.  No checking is done to ensure that this is valid HTML.
+				 * @return
+				 * 		Response object with a media type of "text/html"
+				 */
+				public static Response html(String html) { return new Response(html.getBytes(StandardCharsets.UTF_8), MediaType.TEXT_HTML); }
+				/**
+				 * Creates an JSON response from a String
+				 * 
+				 * @param json
+				 * 		String containing JSON.  No checking is done to ensure that this is valid JSON.
+				 * @return
+				 * 		Response object with a media type of "application/html"
+				 */
+				public static Response json(String json) { return new Response(json.getBytes(StandardCharsets.UTF_8), MediaType.APPLICATION_JSON); }
+				/**
+				 * Creates an XML response from a String
+				 * 
+				 * @param xml
+				 * 		String containing XML.  No checking is done to ensure that this is valid XML.
+				 * @return
+				 * 		Response object with a media type of "application/xml"
+				 */
+				public static Response xml(String xml) { return new Response(xml.getBytes(StandardCharsets.UTF_8), MediaType.APPLICATION_XML); }
+			};
 			/**
 			 * A Temporary Redirect (307 HTTP status code) response
 			 */

--- a/spring/fluentforms-spring-boot-autoconfigure/src/main/java/com/_4point/aem/fluentforms/spring/AemProxyAfSubmission.java
+++ b/spring/fluentforms-spring-boot-autoconfigure/src/main/java/com/_4point/aem/fluentforms/spring/AemProxyAfSubmission.java
@@ -92,7 +92,7 @@ public class AemProxyAfSubmission {
 	 * @return
 	 * @throws IOException
 	 */
-	public static FormDataMultiPart transformFormData(final FormDataMultiPart inFormData, final Map<String, Function<byte[], byte[]>> fieldFunctions, Logger logger) {
+	private static FormDataMultiPart transformFormData(final FormDataMultiPart inFormData, final Map<String, Function<byte[], byte[]>> fieldFunctions, Logger logger) {
 		try {
 			FormDataMultiPart outFormData = new FormDataMultiPart();
 			var fields = inFormData.getFields();
@@ -169,7 +169,7 @@ public class AemProxyAfSubmission {
 	 * Spring context.  
 	 * 
 	 */
-	public static class AfSubmitAemProxyProcessor implements AfSubmitProcessor {
+	static class AfSubmitAemProxyProcessor implements AfSubmitProcessor {
 
 		private final AemConfiguration aemConfig;
 		private final Client httpClient;
@@ -272,7 +272,7 @@ public class AemProxyAfSubmission {
 	 *        ALL - process all handlers that canHandle a request.
 	 * 
 	 */
-	public static class AfSubmitLocalProcessor implements AfSubmitProcessor {
+	static class AfSubmitLocalProcessor implements AfSubmitProcessor {
 		private final static Logger logger = LoggerFactory.getLogger(AfSubmitLocalProcessor.class);
 		private static final String REMAINDER_PATH_SUFFIX = "/jcr:content/guideContainer.af.submit.jsp";
 
@@ -290,7 +290,7 @@ public class AemProxyAfSubmission {
 		
 		private final List<AfSubmissionHandler> submissionHandlers;
 
-		private AfSubmitLocalProcessor(List<AfSubmissionHandler> submissionHandlers) {
+		AfSubmitLocalProcessor(List<AfSubmissionHandler> submissionHandlers) {
 			this.submissionHandlers = submissionHandlers;
 			logger.atInfo().addArgument(submissionHandlers.size()).log("Found {} available AfSubmissionHandlers.");
 			if(logger.isDebugEnabled()) {

--- a/spring/fluentforms-spring-boot-autoconfigure/src/main/java/com/_4point/aem/fluentforms/spring/AemProxyAutoConfiguration.java
+++ b/spring/fluentforms-spring-boot-autoconfigure/src/main/java/com/_4point/aem/fluentforms/spring/AemProxyAutoConfiguration.java
@@ -1,12 +1,21 @@
 package com._4point.aem.fluentforms.spring;
 
+import java.util.List;
+
 import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication.Type;
 import org.springframework.boot.autoconfigure.jersey.ResourceConfigCustomizer;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
+
+import com._4point.aem.fluentforms.spring.AemProxyAfSubmission.AfSubmitLocalProcessor.AfSubmissionHandler;
+import com._4point.aem.fluentforms.spring.AemProxyAfSubmission.AfSubmitLocalProcessor;
+import com._4point.aem.fluentforms.spring.AemProxyAfSubmission.AfSubmitAemProxyProcessor;
+import com._4point.aem.fluentforms.spring.AemProxyAfSubmission.AfSubmitProcessor;
 
 /**
  * AutoConfiguration for the Reverse Proxy Library which reverse proxies secondary
@@ -18,11 +27,64 @@ import org.springframework.context.annotation.Bean;
 @EnableConfigurationProperties({AemConfiguration.class, AemProxyConfiguration.class})
 public class AemProxyAutoConfiguration {
 
+	/**
+	 * Configures the JAX-RS resources associated with reverse proxying resources and submissions from
+	 * Adaptive Forms. 
+	 * 
+	 * @param aemConfig
+	 * 		AEM configuration typically configured using application.properties files.  This is
+	 * 		typically injected by the Spring Framework.
+	 * @param aemProxyConfig
+	 * 		AEM proxy-specific configuration typically configured using application.properties files.
+	 * 		This is typically injected by the Spring Framework.
+	 * @return
+	 * 		JAX-RS Resource configuration customizer that is used by the spring-jersey starter to configure
+	 * 		JAX-RS Resources (i.e. endpoints)
+	 */
 	@Bean
 	public ResourceConfigCustomizer afProxyConfigurer(AemConfiguration aemConfig, AemProxyConfiguration aemProxyConfig) {
 		return config->config.register(new AemProxyEndpoint(aemConfig, aemProxyConfig))
-							 // TODO:  Make this registration conditional on there being available submit handlers
 					  		 .register(new AemProxyAfSubmission())
 					  		 ;
+	}
+	
+	/**
+	 * Supply a AfSubmitLocalProcessor if the user has not already supplied one *and* there is an 
+	 * available AfSubmissionHandler
+	 * 
+	 * Basically, a user can supply their own AfSubmitProcessor if they want to process things
+	 * at the JAX-RS Servlet level.  I expect this to be an unusual case, most users will want
+	 * to either process things locally using a custom AfSubmissionHandler or the will
+	 * want to forward things to AEM by *not* providing a custom AfSubmissionHandler.
+	 * 
+	 * @param submissionHandlers
+	 * 		List of local submission handlers.  This is injected by the Spring Framework.
+	 * @return
+	 * 		Processor that will call the first submission handler that says that it can
+	 * 		process this request.
+	 */
+	@ConditionalOnMissingBean(AfSubmitProcessor.class)
+	@ConditionalOnBean(AfSubmissionHandler.class)
+	@Bean
+	public AfSubmitProcessor localSubmitProcessor(List<AfSubmissionHandler> submissionHandlers) {
+		return new AfSubmitLocalProcessor(submissionHandlers);
+	}
+	
+	/**
+	 * Supply a AfSubmitAemProxyProcessor if the user has not supplied any of the AfSubmit beans.
+	 * 
+	 * This is the default processor and it will forward all submissions on to the configured AEM
+	 * instance.
+	 * 
+	 * @param aemConfig
+	 * 		AEM configuration typically configured using application.properties files.  This is
+	 * 		typically injected by the Spring Framework.
+	 * @return
+	 * 		Processor that forwards all submissions on to AEM.
+	 */
+	@ConditionalOnMissingBean({AfSubmitProcessor.class, AfSubmissionHandler.class})
+	@Bean
+	public AfSubmitProcessor aemSubmitProcessor(AemConfiguration aemConfig) {
+		return new AfSubmitAemProxyProcessor(aemConfig);
 	}
 }

--- a/spring/fluentforms-spring-boot-autoconfigure/src/main/java/com/_4point/aem/fluentforms/spring/AemProxyAutoConfiguration.java
+++ b/spring/fluentforms-spring-boot-autoconfigure/src/main/java/com/_4point/aem/fluentforms/spring/AemProxyAutoConfiguration.java
@@ -20,6 +20,9 @@ public class AemProxyAutoConfiguration {
 
 	@Bean
 	public ResourceConfigCustomizer afProxyConfigurer(AemConfiguration aemConfig, AemProxyConfiguration aemProxyConfig) {
-		return config->config.register(new AemProxyEndpoint(aemConfig, aemProxyConfig));
+		return config->config.register(new AemProxyEndpoint(aemConfig, aemProxyConfig))
+							 // TODO:  Make this registration conditional on there being available submit handlers
+					  		 .register(new AemProxyAfSubmission())
+					  		 ;
 	}
 }

--- a/spring/fluentforms-spring-boot-autoconfigure/src/main/java/com/_4point/aem/fluentforms/spring/AemProxyAutoConfiguration.java
+++ b/spring/fluentforms-spring-boot-autoconfigure/src/main/java/com/_4point/aem/fluentforms/spring/AemProxyAutoConfiguration.java
@@ -12,7 +12,7 @@ import org.springframework.boot.autoconfigure.jersey.ResourceConfigCustomizer;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 
-import com._4point.aem.fluentforms.spring.AemProxyAfSubmission.AfSubmitLocalProcessor.AfSubmissionHandler;
+import com._4point.aem.fluentforms.spring.AemProxyAfSubmission.AfSubmissionHandler;
 import com._4point.aem.fluentforms.spring.AemProxyAfSubmission.AfSubmitLocalProcessor;
 import com._4point.aem.fluentforms.spring.AemProxyAfSubmission.AfSubmitAemProxyProcessor;
 import com._4point.aem.fluentforms.spring.AemProxyAfSubmission.AfSubmitProcessor;

--- a/spring/fluentforms-spring-boot-autoconfigure/src/test/java/com/_4point/aem/fluentforms/spring/AemProxyAfSubmissionTest.java
+++ b/spring/fluentforms-spring-boot-autoconfigure/src/test/java/com/_4point/aem/fluentforms/spring/AemProxyAfSubmissionTest.java
@@ -27,7 +27,7 @@ import org.springframework.stereotype.Component;
 
 import com._4point.aem.fluentforms.spring.AemProxyAfSubmission.AfSubmitAemProxyProcessor;
 import com._4point.aem.fluentforms.spring.AemProxyAfSubmission.AfSubmitLocalProcessor;
-import com._4point.aem.fluentforms.spring.AemProxyAfSubmission.AfSubmitLocalProcessor.AfSubmissionHandler;
+import com._4point.aem.fluentforms.spring.AemProxyAfSubmission.AfSubmissionHandler;
 import com._4point.aem.fluentforms.spring.AemProxyAfSubmission.AfSubmitProcessor;
 import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.junit5.WireMockTest;

--- a/spring/fluentforms-spring-boot-autoconfigure/src/test/java/com/_4point/aem/fluentforms/spring/AemProxyAfSubmissionTest.java
+++ b/spring/fluentforms-spring-boot-autoconfigure/src/test/java/com/_4point/aem/fluentforms/spring/AemProxyAfSubmissionTest.java
@@ -1,0 +1,124 @@
+package com._4point.aem.fluentforms.spring;
+
+import static com._4point.aem.fluentforms.spring.AemProxyAfSubmissionTest.TestApplication.JerseyConfig;
+import static com._4point.aem.fluentforms.spring.AemProxyAfSubmissionTest.MockSubmitProcessor;
+import static com._4point.testing.matchers.jaxrs.ResponseMatchers.isStatus;
+import static com._4point.testing.matchers.jaxrs.ResponseMatchers.hasEntity;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.net.URI;
+
+import org.glassfish.jersey.client.ClientProperties;
+import org.glassfish.jersey.media.multipart.FormDataMultiPart;
+import org.glassfish.jersey.media.multipart.MultiPartFeature;
+import org.glassfish.jersey.server.ResourceConfig;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.stereotype.Component;
+
+import com._4point.aem.fluentforms.spring.AemProxyAfSubmission.AfSubmitProcessor;
+import com._4point.aem.fluentforms.spring.AemProxyAutoConfigurationTest.TestApplication;
+
+import jakarta.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.client.WebTarget;
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT, 
+				classes = {TestApplication.class, JerseyConfig.class, MockSubmitProcessor.class}
+//				,properties = "debug"
+				)
+class AemProxyAfSubmissionTest {
+	public static final String AF_TEMPLATE_NAME = "sample00002test";
+	private static final String SUBMIT_ADAPTIVE_FORM_SERVICE_PATH = "/aem/content/forms/af/" + AF_TEMPLATE_NAME + "/jcr:content/guideContainer.af.submit.jsp";
+	public static final MediaType APPLICATION_PDF = new MediaType("application", "pdf");
+
+	@LocalServerPort
+	private int port;
+
+	private URI uri;
+
+	private WebTarget target;
+
+	@BeforeEach
+	public void setUp() throws Exception {
+		this.uri = getBaseUri(port);
+		target = ClientBuilder.newClient() //newClient(clientConfig)
+				 .property(ClientProperties.FOLLOW_REDIRECTS, Boolean.FALSE)	// Disable re-directs so that we can test for "thank you page" redirection.
+				 .register(MultiPartFeature.class)
+				 .target(this.uri);
+	}
+
+
+	@Test
+	void test() {
+		final FormDataMultiPart getPdfForm = mockFormData("foo", "bar");
+		
+		Response response = target
+				 .path(SUBMIT_ADAPTIVE_FORM_SERVICE_PATH)
+				 .request()
+				 .accept(APPLICATION_PDF)
+				 .post(Entity.entity(getPdfForm, getPdfForm.getMediaType()));
+
+		assertThat(response, allOf(isStatus(Response.Status.OK), hasEntity()));
+	}
+
+	/* package */ static FormDataMultiPart mockFormData(String redirect, String data) {
+		final FormDataMultiPart getPdfForm = new FormDataMultiPart();
+		getPdfForm.field("guideContainerPath", "/aem/content/forms/af/" + AF_TEMPLATE_NAME + "/jcr:content/guideContainer")
+				  .field("aemFormComponentPath", "")
+				  .field("_asyncSubmit", "false")
+				  .field("_charset_", "UTF-8")
+				  .field("runtimeLocale", "en")
+				  .field("fileAttachmentMap", "{}")
+				  .field("afSubmissionInfo", "{\"computedMetaInfo\":{},\"stateOverrides\":{},\"signers\":{}}")
+				  .field("TextField1", "TextField1 Contents")
+				  .field("TextField2", "TextField2 Contents")
+				  .field("jcr:data", data)
+				  .field(":redirect", redirect)
+				  .field(":selfUrl", "/aem/content/forms/af/" + AF_TEMPLATE_NAME)
+				  .field("_guideValueMap", "yes")
+				  .field("_guideValuesMap", "{\"textdraw1555538078737\":\"<p style=\\\"text-align: center;\\\"><b>Sample Form</b></p>\\n\",\"TextField1\":\"DFGDFG\",\"TextField2\":\"DFGDG 233\",\"submit\":null}")
+				  .field("_guideAttachments", "")
+				  .field(":cq_csrf_token", "eyJleHAiOjE1NjU2MzUzNzcsImlhdCI6MTU2NTYzNDc3N30.9KB9yPr_mvIfyiwzn5S8mMh-yUzD0-BF99cJR7vW49M");
+		return getPdfForm;
+	}
+
+	private static String getBaseUriString(int port) {
+		return getBaseUri(port).toString();
+	}
+
+	private static URI getBaseUri(int port) {
+		return URI.create("http://localhost:" + port);
+	}
+
+	@SpringBootApplication()
+	@EnableConfigurationProperties({AemConfiguration.class,AemProxyConfiguration.class})
+	public static class TestApplication {
+		public static void main(String[] args) {
+			SpringApplication.run(TestApplication.class, args);
+		}
+
+		@Component
+		public static class JerseyConfig extends ResourceConfig {
+		}
+	}
+	
+	@Component
+	public static class MockSubmitProcessor implements AfSubmitProcessor {
+		@Override
+		public Response processRequest(FormDataMultiPart inFormData, HttpHeaders headers, String remainder) {
+			return Response.ok().entity("body").build();
+		}
+	}
+}

--- a/spring/fluentforms-spring-boot-autoconfigure/src/test/java/com/_4point/aem/fluentforms/spring/AutoConfigurationTest.java
+++ b/spring/fluentforms-spring-boot-autoconfigure/src/test/java/com/_4point/aem/fluentforms/spring/AutoConfigurationTest.java
@@ -13,6 +13,10 @@ import org.springframework.boot.test.context.runner.WebApplicationContextRunner;
 import org.springframework.boot.autoconfigure.jersey.ResourceConfigCustomizer;
 
 import com._4point.aem.fluentforms.api.output.OutputService;
+import com._4point.aem.fluentforms.spring.AemProxyAfSubmission.AfSubmitAemProxyProcessor;
+import com._4point.aem.fluentforms.spring.AemProxyAfSubmission.AfSubmitLocalProcessor;
+import com._4point.aem.fluentforms.spring.AemProxyAfSubmission.AfSubmitLocalProcessor.AfSubmissionHandler;
+import com._4point.aem.fluentforms.spring.AemProxyAfSubmission.AfSubmitProcessor;
 
 /**
  * Test that AutoCOnfiguration happens.  The code in this test class is based on the following docs:
@@ -24,6 +28,8 @@ class AutoConfigurationTest {
 	
 	private static final AutoConfigurations AUTO_CONFIG = AutoConfigurations.of(FluentFormsAutoConfiguration.class, AemProxyAutoConfiguration.class);
 	
+	private static final AutoConfigurations LOCAL_SUBMIT_CONFIG = AutoConfigurations.of(FluentFormsAutoConfiguration.class, AemProxyAutoConfiguration.class, DummyLocalSubmitHandler.class);
+	
 	// Tests to make sure that only the FluentFormsLibraries are loaded in a non-web application.
 	private static final ContextConsumer<? super AssertableApplicationContext> FF_LIBRARIES_ONLY = (context) -> {
 		assertAll(
@@ -32,7 +38,9 @@ class AutoConfigurationTest {
 				()->assertThat(context).hasSingleBean(OutputService.class),
 				()->assertThat(context).getBean("outputService").isNotNull(),
 				()->assertThat(context).doesNotHaveBean(AemProxyAutoConfiguration.class),
-				()->assertThat(context).doesNotHaveBean(ResourceConfigCustomizer.class)
+				()->assertThat(context).doesNotHaveBean(ResourceConfigCustomizer.class),
+				()->assertThat(context).doesNotHaveBean(AfSubmitProcessor.class),
+				()->assertThat(context).doesNotHaveBean(AfSubmissionHandler.class)
 				);
 		};
 
@@ -44,12 +52,14 @@ class AutoConfigurationTest {
 				()->assertThat(context).hasSingleBean(OutputService.class),
 				()->assertThat(context).getBean("outputService").isNotNull(),
 				()->assertThat(context).doesNotHaveBean(AemProxyAutoConfiguration.class),
-				()->assertThat(context).doesNotHaveBean(ResourceConfigCustomizer.class)
+				()->assertThat(context).doesNotHaveBean(ResourceConfigCustomizer.class),
+				()->assertThat(context).doesNotHaveBean(AfSubmitProcessor.class),
+				()->assertThat(context).doesNotHaveBean(AfSubmissionHandler.class)
 				);
 	};
 
-	// Tests to make sure that all beans are loaded in a web application.
-	private static final ContextConsumer<? super AssertableWebApplicationContext> WEB_ALL_SERVICES = (context) -> {
+	// Tests to make sure that all beans are loaded by default in a web application.
+	private static final ContextConsumer<? super AssertableWebApplicationContext> WEB_ALL_DEFAULT_SERVICES = (context) -> {
 		assertAll(
 				()->assertThat(context).hasSingleBean(FluentFormsAutoConfiguration.class),
 				()->assertThat(context).getBean("fluentFormsAutoConfiguration").isSameAs(context.getBean(FluentFormsAutoConfiguration.class)),
@@ -58,7 +68,27 @@ class AutoConfigurationTest {
 				()->assertThat(context).hasSingleBean(AemProxyAutoConfiguration.class),
 				()->assertThat(context).getBean("aemProxyAutoConfiguration").isSameAs(context.getBean(AemProxyAutoConfiguration.class)),
 				()->assertThat(context).hasSingleBean(ResourceConfigCustomizer.class),
-				()->assertThat(context).getBean("afProxyConfigurer").isNotNull()
+				()->assertThat(context).getBean("afProxyConfigurer").isNotNull(),
+				()->assertThat(context).hasSingleBean(AfSubmitProcessor.class),
+				()->assertThat(context).getBean(AfSubmitProcessor.class).isSameAs(context.getBean(AfSubmitAemProxyProcessor.class)),
+				()->assertThat(context).doesNotHaveBean(AfSubmissionHandler.class)
+				);
+	};
+
+	// Tests to make sure that all beans are loaded in a web application that contains a local submit handler.
+	private static final ContextConsumer<? super AssertableWebApplicationContext> WEB_LOCAL_SUBMIT_SERVICES = (context) -> {
+		assertAll(
+				()->assertThat(context).hasSingleBean(FluentFormsAutoConfiguration.class),
+				()->assertThat(context).getBean("fluentFormsAutoConfiguration").isSameAs(context.getBean(FluentFormsAutoConfiguration.class)),
+				()->assertThat(context).hasSingleBean(OutputService.class),
+				()->assertThat(context).getBean("outputService").isNotNull(),
+				()->assertThat(context).hasSingleBean(AemProxyAutoConfiguration.class),
+				()->assertThat(context).getBean("aemProxyAutoConfiguration").isSameAs(context.getBean(AemProxyAutoConfiguration.class)),
+				()->assertThat(context).hasSingleBean(ResourceConfigCustomizer.class),
+				()->assertThat(context).getBean("afProxyConfigurer").isNotNull(),
+				()->assertThat(context).hasSingleBean(AfSubmitProcessor.class),
+				()->assertThat(context).getBean(AfSubmitProcessor.class).isSameAs(context.getBean(AfSubmitLocalProcessor.class)),
+				()->assertThat(context).hasSingleBean(AfSubmissionHandler.class)
 				);
 	};
 
@@ -67,6 +97,9 @@ class AutoConfigurationTest {
 
 	private final WebApplicationContextRunner webContextRunner = new WebApplicationContextRunner()
 		    .withConfiguration(AUTO_CONFIG);
+
+	private final WebApplicationContextRunner webLocalSubmitContextRunner = new WebApplicationContextRunner()
+		    .withConfiguration(LOCAL_SUBMIT_CONFIG);
 
 	// Only the services that do not require a web server should be started.
 	@Test
@@ -83,7 +116,7 @@ class AutoConfigurationTest {
 	    this.webContextRunner
 	    		.withPropertyValues("fluentforms.aem.servername=localhost", "fluentforms.aem.port=4502",
 	    							"fluentforms.aem.user=user", "fluentforms.aem.password=password")
-	    		.run(WEB_ALL_SERVICES);
+	    		.run(WEB_ALL_DEFAULT_SERVICES);
 	}
 
 	// Only the FluentForms libraries are instantiated when the proxy is explicitly disabled.
@@ -113,6 +146,29 @@ class AutoConfigurationTest {
 	    		.withPropertyValues("fluentforms.aem.servername=localhost", "fluentforms.aem.port=4502",
 	    							"fluentforms.aem.user=user", "fluentforms.aem.password=password",
 	    							"fluentforms.rproxy.enabled=true")
-	    		.run(WEB_ALL_SERVICES);
+	    		.run(WEB_ALL_DEFAULT_SERVICES);
+	}
+	
+	// All services should start when a proper web context has been initialized.
+	@Test
+	void webContext_StartAllServices_LocalSubmit() {
+	    this.webLocalSubmitContextRunner
+	    		.withPropertyValues("fluentforms.aem.servername=localhost", "fluentforms.aem.port=4502",
+	    							"fluentforms.aem.user=user", "fluentforms.aem.password=password")
+	    		.run(WEB_LOCAL_SUBMIT_SERVICES);
+	}
+
+
+	public static class DummyLocalSubmitHandler implements AfSubmissionHandler {
+
+		@Override
+		public boolean canHandle(String formName) {
+			return false;
+		}
+
+		@Override
+		public SubmitResponse processSubmission(Submission submission) {
+			return null;
+		}
 	}
 }

--- a/spring/fluentforms-spring-boot-autoconfigure/src/test/java/com/_4point/aem/fluentforms/spring/AutoConfigurationTest.java
+++ b/spring/fluentforms-spring-boot-autoconfigure/src/test/java/com/_4point/aem/fluentforms/spring/AutoConfigurationTest.java
@@ -15,7 +15,7 @@ import org.springframework.boot.autoconfigure.jersey.ResourceConfigCustomizer;
 import com._4point.aem.fluentforms.api.output.OutputService;
 import com._4point.aem.fluentforms.spring.AemProxyAfSubmission.AfSubmitAemProxyProcessor;
 import com._4point.aem.fluentforms.spring.AemProxyAfSubmission.AfSubmitLocalProcessor;
-import com._4point.aem.fluentforms.spring.AemProxyAfSubmission.AfSubmitLocalProcessor.AfSubmissionHandler;
+import com._4point.aem.fluentforms.spring.AemProxyAfSubmission.AfSubmissionHandler;
 import com._4point.aem.fluentforms.spring.AemProxyAfSubmission.AfSubmitProcessor;
 
 /**

--- a/spring/fluentforms-spring-boot-starter/pom.xml
+++ b/spring/fluentforms-spring-boot-starter/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.1.0</version>
+		<version>3.1.2</version>
 		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 	<artifactId>fluentforms-spring-boot-starter</artifactId>


### PR DESCRIPTION
Added support for accepting Adaptive Form submits.

There are two "out of the box" options:
1) Forward the submission back to AEM and return AEM's response. (default)
2) Intercept the submission and route it to custom code (if one or more AfSubmitHandler beans are available in the Spring context)