### PR TITLE
Fix issue 63 ConvertPdfService toPS() fails

### DIFF
--- a/rest-services/client/src/main/java/com/_4point/aem/docservices/rest_services/client/convertPdf/RestServicesConvertPdfServiceAdapter.java
+++ b/rest-services/client/src/main/java/com/_4point/aem/docservices/rest_services/client/convertPdf/RestServicesConvertPdfServiceAdapter.java
@@ -227,7 +227,7 @@ public class RestServicesConvertPdfServiceAdapter extends RestServicesServiceAda
 		Objects.requireNonNull(inPdfDoc, "inPdfDoc argument cannot be null.");
 		Objects.requireNonNull(toPSOptionsSpec, "ToPSOptionsSpec argument cannot be null.");
 		
-		try (MultipartPayload payload = toImageRestClient.multipartPayloadBuilder()
+		try (MultipartPayload payload = toPsRestClient.multipartPayloadBuilder()
 														 .add(PDF_PARAM, inPdfDoc, ContentType.APPLICATION_PDF)
 														 .addStringVersion(COLOR_PARAM, toPSOptionsSpec.getColor())
 														 .addStringVersion(FONT_INCLUSION_PARAM, toPSOptionsSpec.getFontInclusion())

--- a/rest-services/client/src/test/java/com/_4point/aem/docservices/rest_services/client/convertPdf/RestServicesConvertPdfServiceAdapterTest.java
+++ b/rest-services/client/src/test/java/com/_4point/aem/docservices/rest_services/client/convertPdf/RestServicesConvertPdfServiceAdapterTest.java
@@ -123,7 +123,8 @@ public class RestServicesConvertPdfServiceAdapterTest {
 //	private static final MediaType APPLICATION_PS = new MediaType("application", "postscript");
 
 	@Mock(stubOnly = true) RestClientFactory mockClientFactory;
-	@Mock(stubOnly = true) RestClient mockClient;
+	@Mock(stubOnly = true) RestClient mockClientToImage;
+	@Mock(stubOnly = true) RestClient mockClientToPs;
 	@Mock(stubOnly = true) MultipartPayload mockPayload;
 	@Mock(stubOnly = true) MultipartPayload.Builder mockPayloadBuilder;
 	@Mock(stubOnly = true) Response mockResponse;
@@ -137,7 +138,8 @@ public class RestServicesConvertPdfServiceAdapterTest {
 	
 	@BeforeEach
 	void setUp() throws Exception {
-		when(mockClientFactory.apply(aemConfig.capture(), servicePath.capture(), correlationIdFn.capture())).thenReturn(mockClient);
+		when(mockClientFactory.apply(aemConfig.capture(), Mockito.contains("ToImage"), correlationIdFn.capture())).thenReturn(mockClientToImage);
+		when(mockClientFactory.apply(aemConfig.capture(), Mockito.contains("ToPS"), correlationIdFn.capture())).thenReturn(mockClientToPs);
 	}
 
 	@Test
@@ -167,7 +169,7 @@ public class RestServicesConvertPdfServiceAdapterTest {
 	@Test
 	void testToImage_HappyPath() throws Exception {
 		byte[] responseData = "response Document Data".getBytes();
-		setupMocks(setupMockResponse(responseData, ContentType.IMAGE_JPEG));
+		setupMocks(mockClientToImage, setupMockResponse(responseData, ContentType.IMAGE_JPEG));
 			
 		RestServicesConvertPdfServiceAdapter underTest = createAdapter(mockClientFactory);
 		
@@ -240,7 +242,7 @@ public class RestServicesConvertPdfServiceAdapterTest {
 		var underTest = createAdapter(mockClientFactory);
 		when(toImageOptionsSpec.getImageConvertFormat()).thenReturn(ImageConvertFormat.TIFF);
 
-		var ex = mockForException(cause, ()->underTest.toImage(DUMMY_PDF, toImageOptionsSpec));
+		var ex = mockForException(mockClientToImage, cause, ()->underTest.toImage(DUMMY_PDF, toImageOptionsSpec));
 		
 		assertThat(ex, allOf(ExceptionMatchers.exceptionMsgContainsAll("Error while POSTing to server"),
 							 ExceptionMatchers.hasCause(cause)
@@ -255,7 +257,7 @@ public class RestServicesConvertPdfServiceAdapterTest {
 		var underTest = createAdapter(mockClientFactory);
 		when(toImageOptionsSpec.getImageConvertFormat()).thenReturn(ImageConvertFormat.PNG);
 		
-		var ex = mockForException(cause, ()->underTest.toImage(DUMMY_PDF, toImageOptionsSpec));
+		var ex = mockForException(mockClientToImage, cause, ()->underTest.toImage(DUMMY_PDF, toImageOptionsSpec));
 
 		assertThat(ex, allOf(ExceptionMatchers.exceptionMsgContainsAll("I/O Error while securing document"),
 				 			 ExceptionMatchers.hasCause(cause)
@@ -265,7 +267,7 @@ public class RestServicesConvertPdfServiceAdapterTest {
 	@Test
 	void testToPS_HappyPath() throws Exception {
 		byte[] responseData = "response Document Data".getBytes();
-		setupMocks(setupMockResponse(responseData, ContentType.APPLICATION_PS));
+		setupMocks(mockClientToPs, setupMockResponse(responseData, ContentType.APPLICATION_PS));
 		
 		RestServicesConvertPdfServiceAdapter underTest = createAdapter(mockClientFactory);
 
@@ -347,7 +349,7 @@ public class RestServicesConvertPdfServiceAdapterTest {
 		var toPSOptionsSpec = Mockito.mock(ToPSOptionsSpec.class);
 		var underTest = createAdapter(mockClientFactory);
 		
-		var ex = mockForException(cause, ()->underTest.toPS(DUMMY_PDF, toPSOptionsSpec));
+		var ex = mockForException(mockClientToPs, cause, ()->underTest.toPS(DUMMY_PDF, toPSOptionsSpec));
 		
 		assertThat(ex, allOf(ExceptionMatchers.exceptionMsgContainsAll("Error while POSTing to server"),
 							 ExceptionMatchers.hasCause(cause)
@@ -361,14 +363,14 @@ public class RestServicesConvertPdfServiceAdapterTest {
 		var toPSOptionsSpec = Mockito.mock(ToPSOptionsSpec.class);
 		var underTest = createAdapter(mockClientFactory);
 		
-		var ex = mockForException(cause, ()->underTest.toPS(DUMMY_PDF, toPSOptionsSpec));
+		var ex = mockForException(mockClientToPs, cause, ()->underTest.toPS(DUMMY_PDF, toPSOptionsSpec));
 		
 		assertThat(ex, allOf(ExceptionMatchers.exceptionMsgContainsAll("I/O Error while securing document"),
 	 			 ExceptionMatchers.hasCause(cause)
 			     ));
 	}
 
-	private <T extends Exception> ConvertPdfServiceException mockForException(T exception, Executable test) throws Exception {
+	private <T extends Exception> ConvertPdfServiceException mockForException(RestClient mockClient, T exception, Executable test) throws Exception {
 		
 		Builder mockPayloadBuilder2 = Mockito.mock(Builder.class, Answers.RETURNS_SELF);
 		when(mockClient.multipartPayloadBuilder()).thenReturn(mockPayloadBuilder2);
@@ -395,7 +397,7 @@ public class RestServicesConvertPdfServiceAdapterTest {
 											  .build();
 	}
 
-	private void setupMocks(Optional<Response> mockedResponse) throws RestClientException {
+	private void setupMocks(RestClient mockClient, Optional<Response> mockedResponse) throws RestClientException {
 		when(mockClient.multipartPayloadBuilder()).thenReturn(mockPayloadBuilder);
 		when(mockPayloadBuilder.build()).thenReturn(mockPayload);
 		when(mockPayload.postToServer(acceptableContentType.capture())).thenReturn(mockedResponse);
@@ -406,4 +408,5 @@ public class RestServicesConvertPdfServiceAdapterTest {
 		when(mockResponse.data()).thenReturn(new ByteArrayInputStream(responseData));
 		return Optional.of(mockResponse);
 	}
+	
 }

--- a/rest-services/it.tests/src/test/java/com/_4point/aem/docservices/rest_services/it_tests/client/convertPdf/ToImageTest.java
+++ b/rest-services/it.tests/src/test/java/com/_4point/aem/docservices/rest_services/it_tests/client/convertPdf/ToImageTest.java
@@ -1,0 +1,70 @@
+package com._4point.aem.docservices.rest_services.it_tests.client.convertPdf;
+
+import static com._4point.aem.docservices.rest_services.it_tests.TestUtils.TEST_MACHINE_AEM_TYPE;
+import static com._4point.aem.docservices.rest_services.it_tests.TestUtils.TEST_USER;
+import static com._4point.aem.docservices.rest_services.it_tests.TestUtils.TEST_USER_PASSWORD;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import com._4point.aem.docservices.rest_services.client.convertPdf.RestServicesConvertPdfServiceAdapter;
+import com._4point.aem.docservices.rest_services.client.jersey.JerseyRestClient;
+import com._4point.aem.docservices.rest_services.it_tests.AemInstance;
+import com._4point.aem.docservices.rest_services.it_tests.TestUtils;
+import com._4point.aem.fluentforms.api.Document;
+import com._4point.aem.fluentforms.impl.convertPdf.ConvertPdfServiceImpl;
+import com.adobe.fd.cpdf.api.enumeration.ImageConvertFormat;
+
+@Disabled("This test is currently disabled because the ToImage service is not working correctly. It is work in progress.")
+@Tag("client-tests")
+public class ToImageTest {
+
+	private static final boolean SAVE_RESULTS = true;
+
+	private ConvertPdfServiceImpl underTest;
+
+	@BeforeAll
+	static void setUpAll() throws Exception {
+		AemInstance.AEM_1.prepareForTests();
+	}
+
+	@BeforeEach
+	void setUp() throws Exception {
+		RestServicesConvertPdfServiceAdapter adapter = RestServicesConvertPdfServiceAdapter.builder(JerseyRestClient.factory())
+				.machineName(AemInstance.AEM_1.aemHost())
+				.port(AemInstance.AEM_1.aemPort())
+				.basicAuthentication(TEST_USER, TEST_USER_PASSWORD)
+				.useSsl(false)
+				.aemServerType(TEST_MACHINE_AEM_TYPE)
+				.build();
+
+		underTest = new ConvertPdfServiceImpl(adapter);
+	}
+
+	@Test
+	@DisplayName("Test toImage() Happy Path.")
+	void testToImage() throws Exception {
+		List<Document> result = underTest.toImage()
+										 .setImageConvertFormat(ImageConvertFormat.PNG)
+										 .executeOn(Files.readAllBytes(TestUtils.LOCAL_SAMPLE_FORM_PDF));
+		
+		if (SAVE_RESULTS) {
+			for (int i = 0; i < result.size(); i++) {
+				Document imageDoc = result.get(i);
+				byte[] imageBytes = imageDoc.getInputStream().readAllBytes();
+				String outputFileName = String.format("ToImageResult_Page%d.png", i + 1);
+				Path outputPath = TestUtils.ACTUAL_RESULTS_DIR.resolve(outputFileName);
+				Files.write(outputPath, imageBytes);
+				System.out.println("Saved result to " + outputPath.toAbsolutePath());
+			}
+		}
+	}
+}

--- a/rest-services/it.tests/src/test/java/com/_4point/aem/docservices/rest_services/it_tests/client/convertPdf/ToPSTest.java
+++ b/rest-services/it.tests/src/test/java/com/_4point/aem/docservices/rest_services/it_tests/client/convertPdf/ToPSTest.java
@@ -26,7 +26,7 @@ import com._4point.aem.fluentforms.impl.convertPdf.ConvertPdfServiceImpl;
 @Tag("client-tests")
 public class ToPSTest {
 
-	private static final boolean SAVE_RESULTS = true;
+	private static final boolean SAVE_RESULTS = false;
 
 	private ConvertPdfServiceImpl underTest;
 

--- a/rest-services/it.tests/src/test/java/com/_4point/aem/docservices/rest_services/it_tests/client/convertPdf/ToPSTest.java
+++ b/rest-services/it.tests/src/test/java/com/_4point/aem/docservices/rest_services/it_tests/client/convertPdf/ToPSTest.java
@@ -1,0 +1,68 @@
+package com._4point.aem.docservices.rest_services.it_tests.client.convertPdf;
+
+import static com._4point.aem.docservices.rest_services.it_tests.TestUtils.TEST_MACHINE_AEM_TYPE;
+import static com._4point.aem.docservices.rest_services.it_tests.TestUtils.TEST_USER;
+import static com._4point.aem.docservices.rest_services.it_tests.TestUtils.TEST_USER_PASSWORD;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import com._4point.aem.docservices.rest_services.client.convertPdf.RestServicesConvertPdfServiceAdapter;
+import com._4point.aem.docservices.rest_services.client.jersey.JerseyRestClient;
+import com._4point.aem.docservices.rest_services.it_tests.AemInstance;
+import com._4point.aem.docservices.rest_services.it_tests.ByteArrayString;
+import com._4point.aem.docservices.rest_services.it_tests.TestUtils;
+import com._4point.aem.fluentforms.api.Document;
+import com._4point.aem.fluentforms.impl.convertPdf.ConvertPdfServiceImpl;
+
+@Tag("client-tests")
+public class ToPSTest {
+
+	private static final boolean SAVE_RESULTS = true;
+
+	private ConvertPdfServiceImpl underTest;
+
+	@BeforeAll
+	static void setUpAll() throws Exception {
+		AemInstance.AEM_1.prepareForTests();
+	}
+
+	@BeforeEach
+	void setUp() throws Exception {
+		RestServicesConvertPdfServiceAdapter adapter = RestServicesConvertPdfServiceAdapter.builder(JerseyRestClient.factory())
+				.machineName(AemInstance.AEM_1.aemHost())
+				.port(AemInstance.AEM_1.aemPort())
+				.basicAuthentication(TEST_USER, TEST_USER_PASSWORD)
+				.useSsl(false)
+				.aemServerType(TEST_MACHINE_AEM_TYPE)
+				.build();
+
+		underTest = new ConvertPdfServiceImpl(adapter);
+	}
+
+	@Test
+	@DisplayName("Test toPS() Happy Path.")
+	void testToPS() throws Exception {
+
+		Document result = underTest.toPS()
+				 				   .executeOn(Files.readAllBytes(TestUtils.LOCAL_SAMPLE_FORM_PDF));
+		
+		byte[] resultBytes = result.getInputStream().readAllBytes();
+		
+		if (SAVE_RESULTS) {
+			Path outputPath = TestUtils.ACTUAL_RESULTS_DIR.resolve("ToPSResult.ps");
+			Files.write(outputPath, resultBytes);
+			System.out.println("Saved result to " + outputPath.toAbsolutePath());
+		}
+		
+		assertThat("Expected PostScript to be returned.", ByteArrayString.toString(resultBytes, 10), containsString("%, !, P, S, -, A, d, o, b, e"));
+	}
+}

--- a/rest-services/it.tests/src/test/java/com/_4point/aem/docservices/rest_services/it_tests/server/convertPdf/ToImageTest.java
+++ b/rest-services/it.tests/src/test/java/com/_4point/aem/docservices/rest_services/it_tests/server/convertPdf/ToImageTest.java
@@ -1,0 +1,77 @@
+package com._4point.aem.docservices.rest_services.it_tests.server.convertPdf;
+
+import static com._4point.aem.docservices.rest_services.it_tests.TestUtils.LOCAL_SAMPLE_FORM_WITHOUT_DATA_PDF;
+import static com._4point.aem.docservices.rest_services.it_tests.TestUtils.TEST_MACHINE_AEM_TYPE;
+import static com._4point.aem.docservices.rest_services.it_tests.TestUtils.TEST_USER;
+import static com._4point.aem.docservices.rest_services.it_tests.TestUtils.TEST_USER_PASSWORD;
+
+import java.nio.file.Files;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.apache.commons.io.IOUtils;
+import org.glassfish.jersey.client.authentication.HttpAuthenticationFeature;
+import org.glassfish.jersey.media.multipart.FormDataMultiPart;
+import org.glassfish.jersey.media.multipart.MultiPartFeature;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import com._4point.aem.docservices.rest_services.it_tests.AemInstance;
+import com._4point.aem.docservices.rest_services.it_tests.TestUtils;
+
+import jakarta.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.client.WebTarget;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+@Disabled("This test is currently disabled because the ToImage service is not working correctly. It is work in progress.")
+@Tag("server-tests")
+public class ToImageTest {
+	private static final String TO_IMAGE_URL = "http://" + AemInstance.AEM_1.aemHost() + ":" + AemInstance.AEM_1.aemPort() + TEST_MACHINE_AEM_TYPE.pathPrefix() + "/services/ConvertPdfService/ToImage";
+
+	private static final String PDF_PARAM = "inPdfDoc";
+	private static final String IMAGE_CONVERT_FORMAT_PARAM = "toImageOptionsSpec.imageConvertFormat";
+
+	private static final boolean SAVE_RESULTS = true;
+
+	@BeforeAll
+	static void setUpAll() throws Exception {
+		AemInstance.AEM_1.prepareForTests();
+	}
+
+	private WebTarget target;
+
+	@BeforeEach
+	void setUp() throws Exception {
+		HttpAuthenticationFeature feature = HttpAuthenticationFeature.basic(TEST_USER, TEST_USER_PASSWORD); // default AEM passwords
+		target = ClientBuilder.newClient().register(feature).register(MultiPartFeature.class)
+							  .target(TO_IMAGE_URL);
+	}
+
+	@Test
+	void testToImage_MinArgs() throws Exception {
+		byte[] samplePdf = Files.readAllBytes(LOCAL_SAMPLE_FORM_WITHOUT_DATA_PDF);
+		try (final FormDataMultiPart multipart = new FormDataMultiPart()) {
+			multipart.field(PDF_PARAM, samplePdf, new MediaType("application", "pdf"))
+					 .field(IMAGE_CONVERT_FORMAT_PARAM, "TIFF");
+			
+			Response result = target.request()
+					.accept(MediaType.valueOf("image/png"))
+					.post(Entity.entity(multipart, multipart.getMediaType()));
+			
+			assertTrue(result.hasEntity(), "Expected the response to have an entity.");
+			assertEquals(Response.Status.OK.getStatusCode(), result.getStatus(), () -> "Expected response to be 'OK', entity='" + TestUtils.readEntityToString(result) + "'.");
+
+			byte[] resultBytes = result.readEntity(byte[].class);
+			if (SAVE_RESULTS) {
+				IOUtils.write(resultBytes, Files.newOutputStream(TestUtils.ACTUAL_RESULTS_DIR.resolve("testToImage_MinArgs_result.tif")));
+			}		
+		}
+	}
+
+}

--- a/rest-services/it.tests/src/test/java/com/_4point/aem/docservices/rest_services/it_tests/server/convertPdf/ToPSTest.java
+++ b/rest-services/it.tests/src/test/java/com/_4point/aem/docservices/rest_services/it_tests/server/convertPdf/ToPSTest.java
@@ -1,0 +1,76 @@
+package com._4point.aem.docservices.rest_services.it_tests.server.convertPdf;
+
+import static com._4point.aem.docservices.rest_services.it_tests.TestUtils.LOCAL_SAMPLE_FORM_WITHOUT_DATA_PDF;
+import static com._4point.aem.docservices.rest_services.it_tests.TestUtils.TEST_MACHINE_AEM_TYPE;
+import static com._4point.aem.docservices.rest_services.it_tests.TestUtils.TEST_USER;
+import static com._4point.aem.docservices.rest_services.it_tests.TestUtils.TEST_USER_PASSWORD;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Files;
+
+import org.apache.commons.io.IOUtils;
+import org.glassfish.jersey.client.authentication.HttpAuthenticationFeature;
+import org.glassfish.jersey.media.multipart.FormDataMultiPart;
+import org.glassfish.jersey.media.multipart.MultiPartFeature;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import com._4point.aem.docservices.rest_services.it_tests.AemInstance;
+import com._4point.aem.docservices.rest_services.it_tests.ByteArrayString;
+import com._4point.aem.docservices.rest_services.it_tests.TestUtils;
+
+import jakarta.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.client.WebTarget;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+@Tag("server-tests")
+public class ToPSTest {
+	private static final String TO_PS_URL = "http://" + AemInstance.AEM_1.aemHost() + ":" + AemInstance.AEM_1.aemPort() + TEST_MACHINE_AEM_TYPE.pathPrefix() + "/services/ConvertPdfService/ToPS";
+
+	private static final String PDF_PARAM = "inPdfDoc";
+
+	private static final boolean SAVE_RESULTS = false;
+
+	@BeforeAll
+	static void setUpAll() throws Exception {
+		AemInstance.AEM_1.prepareForTests();
+	}
+
+	private WebTarget target;
+
+	@BeforeEach
+	void setUp() throws Exception {
+		HttpAuthenticationFeature feature = HttpAuthenticationFeature.basic(TEST_USER, TEST_USER_PASSWORD); // default AEM passwords
+		target = ClientBuilder.newClient().register(feature).register(MultiPartFeature.class)
+							  .target(TO_PS_URL);
+	}
+
+	@Test
+	void testToPS_NoArgs() throws Exception {
+		byte[] samplePdf = Files.readAllBytes(LOCAL_SAMPLE_FORM_WITHOUT_DATA_PDF);
+		try (final FormDataMultiPart multipart = new FormDataMultiPart()) {
+			multipart.field(PDF_PARAM, samplePdf, new MediaType("application", "pdf"));
+			
+			Response result = target.request()
+					.accept(MediaType.valueOf("application/postscript"))
+					.post(Entity.entity(multipart, multipart.getMediaType()));
+			
+			assertTrue(result.hasEntity(), "Expected the response to have an entity.");
+			assertEquals(Response.Status.OK.getStatusCode(), result.getStatus(), () -> "Expected response to be 'OK', entity='" + TestUtils.readEntityToString(result) + "'.");
+
+			byte[] resultBytes = result.readEntity(byte[].class);
+			if (SAVE_RESULTS) {
+				IOUtils.write(resultBytes, Files.newOutputStream(TestUtils.ACTUAL_RESULTS_DIR.resolve("testToPS_NoArgs_result.ps")));
+			}
+
+			assertThat("Expected PostScript to be returned.", ByteArrayString.toString(resultBytes, 10), containsString("%, !, P, S, -, A, d, o, b, e"));
+		}
+	}
+}


### PR DESCRIPTION
There was a copy/paste error when moving to REST client interface.  This caused the toPS() call to fail.

The bigger problem was that none of the tests (unit or integration) failed.  This indicated a hole in the test suite.  This PR adds integration tests for the ConvertPDF service and improves the unit tests to catch this issue.